### PR TITLE
Remove default main prefix in getAddressBytes function

### DIFF
--- a/src/util/address.ts
+++ b/src/util/address.ts
@@ -214,7 +214,6 @@ export const SWTHAddress: SWTHAddressType = {
   },
 
   getAddressBytes: (bech32Address: string, net: Network): Uint8Array => {
-    // Remove "main" because "main" is not a prefix
     const prefix = SWTHAddress.getBech32Prefix(net, undefined, "main");
     const { prefix: b32Prefix, words } = bech32.decode(bech32Address);
     if (b32Prefix !== prefix) {


### PR DESCRIPTION
This causes an error in Account Settings page on Demex which says `Prefix does not match`