### PR TITLE
Fix metamask login issues on devnet

### DIFF
--- a/src/provider/metamask/MetaMask.ts
+++ b/src/provider/metamask/MetaMask.ts
@@ -1,7 +1,7 @@
 
 import { Network, NetworkConfigs } from '@carbon-sdk/constant'
 import { ABIs } from '@carbon-sdk/eth'
-import { Blockchain, blockchainForChainId, ChainNames, getChainFromID } from '@carbon-sdk/util/blockchain'
+import { Blockchain, getBlockchainFromChain, ChainNames } from '@carbon-sdk/util/blockchain'
 import { ethers } from 'ethers'
 import * as ethSignUtils from 'eth-sig-util'
 import { ETHClient } from '@carbon-sdk/clients/ETHClient'
@@ -211,7 +211,7 @@ export class MetaMask {
   async syncBlockchain(): Promise<MetaMaskSyncResult> {
     const chainIdHex = await this.getAPI()?.request({ method: 'eth_chainId' }) as string
     const chainId = !!chainIdHex ? parseInt(chainIdHex, 16) : undefined
-    const blockchain = blockchainForChainId(chainId)
+    const blockchain = getBlockchainFromChain(chainId)
     this.blockchain = blockchain!
 
     return { chainId, blockchain }
@@ -396,6 +396,11 @@ export class MetaMask {
     if (currentChainId === 97) {
       this.blockchain = Blockchain.BinanceSmartChain
       return currentChainId
+    }
+
+    // Deal with cases where users are logging in to devnet using mainnet chains
+    if (currentChainId === 56) {
+      return 97
     }
     return 3
   }

--- a/src/util/blockchain.ts
+++ b/src/util/blockchain.ts
@@ -37,6 +37,21 @@ export function getChainFromID(id: number): string | undefined {
   return Object.keys(CHAIN_IDS).find((key) => CHAIN_IDS[key] === id)
 }
 
+export const getBlockchainFromChain = (chainId?: number) => {
+  switch (chainId) {
+    case 1:
+    case 3:
+      return Blockchain.Ethereum
+    case 56:
+    case 97:
+      return Blockchain.BinanceSmartChain
+    case 110:
+    case 111:
+      return Blockchain.Zilliqa
+  }
+  return undefined
+}
+
 export const blockchainForChainId = (chainId?: number): Blockchain | undefined => {
   switch (chainId) {
     case 0:


### PR DESCRIPTION
**Situation**
Metamask was showing the `Unrecognised blockchain` error when trying to login to devnet using Ropsten/BSC Testnet

**Solution**
Add function to detect the correct blockchain (previous function was to decipher the blockchain from token chainId)