### PR TITLE
Fix issue where tokenId is empty str (on testnet/devnet/localhost), which hinders usd value query

### DIFF
--- a/examples/query.ts
+++ b/examples/query.ts
@@ -4,7 +4,7 @@ import "./_setup";
 
 (async () => {
   const sdk = await CarbonSDK.instance({
-    network: CarbonSDK.Network.MainNet,
+    network: CarbonSDK.Network.LocalHost,
     config: {
       tmRpcUrl: process.env.TRPC_ENDPOINT,
     },
@@ -15,7 +15,6 @@ import "./_setup";
   // query txn fees
   const fees = await sdk.query.fee.MsgFeeAll({})
   console.log("fees", fees);
-  process.exit(0);
 
   // query all tokens
   const tokens = await sdk.query.coin.TokenAll({

--- a/examples/query.ts
+++ b/examples/query.ts
@@ -4,7 +4,7 @@ import "./_setup";
 
 (async () => {
   const sdk = await CarbonSDK.instance({
-    network: CarbonSDK.Network.LocalHost,
+    network: CarbonSDK.Network.MainNet,
     config: {
       tmRpcUrl: process.env.TRPC_ENDPOINT,
     },
@@ -15,6 +15,7 @@ import "./_setup";
   // query txn fees
   const fees = await sdk.query.fee.MsgFeeAll({})
   console.log("fees", fees);
+  process.exit(0);
 
   // query all tokens
   const tokens = await sdk.query.coin.TokenAll({

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -315,12 +315,8 @@ class TokenClient {
         return accum;
       }
 
-      const tokenId = this.tokenForDenom(denom)?.id;
-      // Deal with tokens with id = "" on testnet/devnet/localhost
-      const id = tokenId
-        ? (tokenId !== "" ? tokenId : denom)
-        : denom;
-      const commonDenom = this.getCommonDenom(id);
+      const tokenId = this.tokenForDenom(denom)?.id ?? "";
+      const commonDenom = this.getCommonDenom(tokenId !== "" ? tokenId : denom);
 
       if (!accum[commonDenom]) {
         accum[commonDenom] = commonDenom;

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -78,7 +78,11 @@ class TokenClient {
 
   public getUSDValue(denom: string): BigNumber | undefined {
     const tokenId = this.tokenForDenom(denom)?.id;
-    const commonDenom = this.getCommonDenom(tokenId ?? denom);
+    // Deal with tokens with id = "" on testnet/devnet/localhost
+    const id = tokenId
+      ? (tokenId !== "" ? tokenId : denom)
+      : denom
+    const commonDenom = this.getCommonDenom(id);
     return this.usdValues[commonDenom];
   }
 
@@ -311,8 +315,12 @@ class TokenClient {
         return accum;
       }
 
-      const tokenId = this.tokenForDenom(denom)?.id ?? "";
-      const commonDenom = this.getCommonDenom(tokenId !== "" ? tokenId : denom);
+      const tokenId = this.tokenForDenom(denom)?.id;
+      // Deal with tokens with id = "" on testnet/devnet/localhost
+      const id = tokenId
+        ? (tokenId !== "" ? tokenId : denom)
+        : denom;
+      const commonDenom = this.getCommonDenom(id);
 
       if (!accum[commonDenom]) {
         accum[commonDenom] = commonDenom;


### PR DESCRIPTION
Bug lies in the getUSDValue query: if token id is an empty string `""`, no usd value will be returned even though it's in the `usdValues` obj