### PR TITLE
Ensure RootStore is not initialised on iOS Safari

### DIFF
--- a/src/CarbonSDK.ts
+++ b/src/CarbonSDK.ts
@@ -13,13 +13,6 @@ import { CarbonSigner, CarbonWallet, CarbonWalletGenericOpts } from "./wallet";
 export { CarbonTx } from "@carbon-sdk/util";
 export { CarbonSigner, CarbonSignerTypes, CarbonWallet, CarbonWalletGenericOpts, CarbonWalletInitOpts } from "@carbon-sdk/wallet";
 
-// Added as a temporary workaround to prevent @keplr-wallet/stores from breaking production site on iOS 15.4 Safari
-// TODO: Check if there are fixes on https://github.com/chainapsis/keplr-wallet to see if this can be removed
-const _window = window as any;
-if (_window?.browser && !_window.browser.storage) {
-  _window.browser.storage = { local: {} }
-}
-
 export interface CarbonSDKOpts {
   network: Network;
   tmClient: Tendermint34Client;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export * as Models from "./codec";
 export * from "./util";
 export { Blockchain } from "./util/blockchain";
 export * from "./websocket";
-export { AminoTypesMap, SDKProvider, KeplrAccount, KeplrWindow, CosmosLedger, Keplr, ChainInfo, EVMChain, MetaMaskChangeNetworkParam, CallContractArgs, MetaMaskSyncResult, MetaMask, EthLedgerAccount, EthLedgerSigner, NeoLedgerAccount, Zilpay, ZilPayChangeNetworkParam, O3Types, O3Wallet, RootStore, createRootStore } from "./provider";
+export { AminoTypesMap, CoinPretty, SDKProvider, KeplrAccount, KeplrWindow, CosmosLedger, Keplr, ChainInfo, EVMChain, MetaMaskChangeNetworkParam, CallContractArgs, MetaMaskSyncResult, MetaMask, EthLedgerAccount, EthLedgerSigner, NeoLedgerAccount, Zilpay, ZilPayChangeNetworkParam, O3Types, O3Wallet } from "./provider";
 export { default as CarbonSDK } from "./CarbonSDK";
 export { ProviderAgent } from "./constant";
 export * as Insights from "./insights";

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,6 +1,6 @@
 export { EthLedgerAccount, EthLedgerSigner, NeoLedgerAccount } from "./account";
 export { AminoTypesMap } from "./amino";
-export { ChainInfo, default as KeplrAccount, Keplr, KeplrWindow, RootStore, createRootStore } from "./keplr";
+export { ChainInfo, CoinPretty, default as KeplrAccount, Keplr, KeplrWindow } from "./keplr";
 export { default as CosmosLedger } from "./ledger";
 export { CallContractArgs, EVMChain, MetaMask, MetaMaskChangeNetworkParam, MetaMaskSyncResult } from "./metamask";
 export { O3Types, O3Wallet } from "./o3";

--- a/src/provider/keplr/KeplrStore.ts
+++ b/src/provider/keplr/KeplrStore.ts
@@ -1,20 +1,21 @@
 import { ChainInfoExplorerTmRpc } from "@carbon-sdk/constant/ibc";
-// import {
-//   AccountStore,
-//   ChainStore,
-//   QueriesStore,
-//   AccountWithCosmos,
-//   QueriesWithCosmos,
-// } from "@keplr-wallet/stores";
-// import { IndexedDBKVStore } from "@keplr-wallet/common";
+import {
+  AccountStore,
+  ChainStore,
+  QueriesStore,
+  AccountWithCosmos,
+  QueriesWithCosmos,
+} from "@keplr-wallet/stores";
+import { IndexedDBKVStore } from "@keplr-wallet/common";
 import { ChainInfo } from "@keplr-wallet/types";
+import { iOS } from "@carbon-sdk/util/external";
 import { EmbedChainInfos } from "@carbon-sdk/util/token";
 
 export class RootStore {
-  // public readonly chainStore: ChainStore;
+  public readonly chainStore: ChainStore;
 
-  // public readonly queriesStore: QueriesStore<QueriesWithCosmos>;
-  // public readonly accountStore: AccountStore<AccountWithCosmos>;
+  public readonly queriesStore: QueriesStore<QueriesWithCosmos>;
+  public readonly accountStore: AccountStore<AccountWithCosmos>;
 
   constructor(getKeplr: () => Promise<any>, additionalChains?: ChainInfo[]) {
     const embedChainInfos = Object.values(EmbedChainInfos).map((chainInfo: ChainInfoExplorerTmRpc) => {
@@ -26,32 +27,36 @@ export class RootStore {
     if (additionalChains && additionalChains?.length > 0) {
       embedChainInfos.push(...additionalChains)
     }
-    // this.chainStore = new ChainStore<ChainInfo>(embedChainInfos);
+    this.chainStore = new ChainStore<ChainInfo>(embedChainInfos);
 
-    // this.queriesStore = new QueriesStore(
-    //   new IndexedDBKVStore("store_queries"),
-    //   this.chainStore,
-    //   getKeplr,
-    //   QueriesWithCosmos,
-    // );
+    this.queriesStore = new QueriesStore(
+      new IndexedDBKVStore("store_queries"),
+      this.chainStore,
+      getKeplr,
+      QueriesWithCosmos,
+    );
 
-    // this.accountStore = new AccountStore(
-    //   window,
-    //   AccountWithCosmos,
-    //   this.chainStore,
-    //   this.queriesStore,
-    //   {
-    //     defaultOpts: {
-    //       prefetching: false,
-    //       suggestChain: true,
-    //       autoInit: true,
-    //       getKeplr,
-    //     },
-    //   }
-    // );
+    this.accountStore = new AccountStore(
+      window,
+      AccountWithCosmos,
+      this.chainStore,
+      this.queriesStore,
+      {
+        defaultOpts: {
+          prefetching: false,
+          suggestChain: true,
+          autoInit: true,
+          getKeplr,
+        },
+      }
+    );
   }
 }
 
-export function createRootStore(getKeplr: () => Promise<any>, additionalChains?: ChainInfo[]) {
+export function createRootStore(getKeplr: () => Promise<any>, additionalChains?: ChainInfo[]): RootStore | null {
+  if (iOS()) {
+    return null
+  }
+
   return new RootStore(getKeplr, additionalChains);
 }

--- a/src/provider/keplr/index.ts
+++ b/src/provider/keplr/index.ts
@@ -1,5 +1,4 @@
 export { default } from "./KeplrAccount";
 export { KeplrWindow } from "./window";
 export { Keplr, ChainInfo } from "@keplr-wallet/types";
-// export { CoinPretty } from "@keplr-wallet/unit";
-export { RootStore, createRootStore } from "./KeplrStore";
+export { CoinPretty } from "@keplr-wallet/unit";

--- a/src/util/external.ts
+++ b/src/util/external.ts
@@ -10,3 +10,9 @@ export interface TokenInitInfo {
   symbol: string
   name: string
 }
+
+// Detect device type
+export function iOS() {
+  return /iPad|iPhone|iPod/.test(navigator.platform)
+    || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+}

--- a/src/util/token.ts
+++ b/src/util/token.ts
@@ -1,5 +1,5 @@
-import { ChainInfoExplorerTmRpc, EmbedChainInfosInit, ibcWhitelist } from "@carbon-sdk/constant";
-// import { Hash } from "@keplr-wallet/crypto";
+import { ChainInfoExplorerTmRpc, EmbedChainInfosInit, ibcWhitelist, ibcAssetObj, ibcDisplayOverride } from "@carbon-sdk/constant";
+import { Hash } from "@keplr-wallet/crypto";
 import { KeplrAccount } from "@carbon-sdk/provider";
 
 import { SimpleMap } from "./type";
@@ -11,21 +11,21 @@ export const FuturesDenomOverride: SimpleMap<string> = {
 };
 
 // Create IBC minimal denom
-// export function makeIBCMinimalDenom(sourceChannelId: string, coinMinimalDenom: string): string {
-// 	return (
-// 		'ibc/' +
-// 		Buffer.from(Hash.sha256(Buffer.from(`transfer/${sourceChannelId}/${coinMinimalDenom}`)))
-// 			.toString('hex')
-// 			.toUpperCase()
-// 	);
-// };
+export function makeIBCMinimalDenom(sourceChannelId: string, coinMinimalDenom: string): string {
+	return (
+		'ibc/' +
+		Buffer.from(Hash.sha256(Buffer.from(`transfer/${sourceChannelId}/${coinMinimalDenom}`)))
+			.toString('hex')
+			.toUpperCase()
+	);
+};
 
-// const swthIbc = ibcAssetObj.assets[ibcDisplayOverride['swth']];
+const swthIbc = ibcAssetObj.assets[ibcDisplayOverride['swth']];
 export const EmbedChainInfos = Object.values(EmbedChainInfosInit).reduce((prev: SimpleMap<ChainInfoExplorerTmRpc>, chainInfo: ChainInfoExplorerTmRpc) => {
 	if (ibcWhitelist.includes(chainInfo.chainId)) {
 		chainInfo.currencies.push({
 			...KeplrAccount.SWTH_CURRENCY,
-			// coinMinimalDenom: makeIBCMinimalDenom(swthIbc.ibc?.dst_channel ?? '', KeplrAccount.SWTH_CURRENCY.coinMinimalDenom),
+			coinMinimalDenom: makeIBCMinimalDenom(swthIbc.ibc?.dst_channel ?? '', KeplrAccount.SWTH_CURRENCY.coinMinimalDenom),
 		})
 	}
 	prev[chainInfo.chainId] = chainInfo;


### PR DESCRIPTION
Ensure RootStore is not initialised on iOS Safari so as to ensure that @keplr-wallet/stores does not crash iOS Safari