### PR TITLE
Fix/dynamic chaininfo

### DIFF
--- a/src/constant/ibc.ts
+++ b/src/constant/ibc.ts
@@ -1,4 +1,5 @@
 import { SimpleMap } from "@carbon-sdk/util/type";
+import { Updated } from "@chain-registry/types";
 import { AppCurrency, Bech32Config, ChainInfo } from "@keplr-wallet/types";
 import * as bech32 from "bech32";
 import { CARBON_GAS_PRICE, GasPriceStep } from "./generic";
@@ -2158,4 +2159,66 @@ export type MinimalDenomMap = SimpleMap<string>;
 
 export interface ExtendedChainInfo extends ChainInfo {
   minimalDenomMap: MinimalDenomMap;
+}
+
+export interface URLProviderObj {
+  address: string;
+  provider: string;
+}
+
+export interface ExplorerObj {
+  kind?: string;
+  tx_page: string;
+  url: string;
+}
+
+export interface ChainRegistryItem {
+  name: string;
+  path: string;
+  chain_name: string;
+  network_type: string;
+  pretty_name: string;
+  chain_id: string;
+  cosmwasm_enabled?: boolean;
+  status: string;
+  bech32_prefix: string;
+  symbol: string;
+  display: string;
+  denom: string;
+  decimals: number;
+  coingecko_id: string;
+  image: string;
+  website: string;
+  height: number;
+  best_apis: {
+    rpc: URLProviderObj[];
+    rest: URLProviderObj[];
+  };
+  proxy_status: {
+    rest: boolean;
+    rpc: boolean;
+  };
+  versions: {
+    application_version: string;
+    cosmos_sdk_version: string;
+    tendermint_version: string;
+  };
+  explorers: ExplorerObj[];
+  params: any;
+  services?: any;
+  prices?: {
+    coingecko: SimpleMap<SimpleMap<number>>;
+  };
+  assets: Updated[];
+  keywords: any[];
+}
+
+export interface CosmosChainsObj {
+  chains: ChainRegistryItem[];
+  repository: {
+    branch: string;
+    commit: string;
+    timestamp: string;
+    url: string;
+  };
 }

--- a/src/constant/ibc.ts
+++ b/src/constant/ibc.ts
@@ -2172,14 +2172,14 @@ export interface ExplorerObj {
   url: string;
 }
 
-interface Asset {
+export interface Asset {
   name: string;
   description: string;
   symbol: string;
   denom: string;
   decimals: number;
   coingecko_id: string;
-  base: DenomUnit;
+  base: string;
   display: DenomUnit;
   denom_units: DenomUnit[];
   logo_URIs: LogoURIs;
@@ -2187,9 +2187,17 @@ interface Asset {
   prices?: Prices;
 }
 
-interface DenomUnit {
+export interface DenomUnit {
   denom: string;
   exponent: number;
+}
+
+export interface FeeToken{
+  denom: string,
+  fixed_min_gas_price: number,
+  low_gas_price: number,
+  average_gas_price: number,
+  high_gas_price: number
 }
 
 interface LogoURIs {

--- a/src/constant/ibc.ts
+++ b/src/constant/ibc.ts
@@ -1,5 +1,4 @@
 import { SimpleMap } from "@carbon-sdk/util/type";
-// import { Updated } from "@chain-registry/types";
 import { AppCurrency, Bech32Config, ChainInfo } from "@keplr-wallet/types";
 import * as bech32 from "bech32";
 import { CARBON_GAS_PRICE, GasPriceStep } from "./generic";
@@ -2192,7 +2191,7 @@ export interface DenomUnit {
   exponent: number;
 }
 
-export interface FeeToken{
+export interface FeeToken {
   denom: string,
   fixed_min_gas_price: number,
   low_gas_price: number,

--- a/src/constant/ibc.ts
+++ b/src/constant/ibc.ts
@@ -1,5 +1,5 @@
 import { SimpleMap } from "@carbon-sdk/util/type";
-import { Updated } from "@chain-registry/types";
+// import { Updated } from "@chain-registry/types";
 import { AppCurrency, Bech32Config, ChainInfo } from "@keplr-wallet/types";
 import * as bech32 from "bech32";
 import { CARBON_GAS_PRICE, GasPriceStep } from "./generic";
@@ -2172,6 +2172,40 @@ export interface ExplorerObj {
   url: string;
 }
 
+interface Asset {
+  name: string;
+  description: string;
+  symbol: string;
+  denom: string;
+  decimals: number;
+  coingecko_id: string;
+  base: DenomUnit;
+  display: DenomUnit;
+  denom_units: DenomUnit[];
+  logo_URIs: LogoURIs;
+  image: string;
+  prices?: Prices;
+}
+
+interface DenomUnit {
+  denom: string;
+  exponent: number;
+}
+
+interface LogoURIs {
+  png: string;
+  svg: string;
+}
+
+interface Prices {
+  coingecko: Coingecko;
+}
+
+interface Coingecko {
+  usd: number;
+}
+
+
 export interface ChainRegistryItem {
   name: string;
   path: string;
@@ -2209,7 +2243,7 @@ export interface ChainRegistryItem {
   prices?: {
     coingecko: SimpleMap<SimpleMap<number>>;
   };
-  assets: Updated[];
+  assets: Asset[];
   keywords: any[];
 }
 

--- a/src/modules/ibc.ts
+++ b/src/modules/ibc.ts
@@ -227,13 +227,14 @@ export class IBCModule extends BaseModule {
           };
         });
         
-
-        const feeCurrencies = chainInfoJson.fees.fee_tokens.map((feeToken: FeeToken) => {
+        // Filter out fee tokens which do not have a corresponding asset
+        const validFeeTokens = chainInfoJson.fees.fee_tokens.filter((feeToken: FeeToken) => {
+          const correspondingAsset = assetListJson.assets.find((asset: Asset) => asset.base === feeToken.denom);
+          return correspondingAsset !== undefined;
+        });
+        const feeCurrencies = validFeeTokens.map((feeToken: FeeToken) => {
           // Find the corresponding asset for the fee token
           const correspondingAsset = assetListJson.assets.find((asset: Asset) => asset.base === feeToken.denom);
-          if (!correspondingAsset) {
-            return IBCUtils.EmbedChainInfos[chainId];
-          }
           // Find the denom_unit with the maximum exponent
           const maxExponentDenomUnit = correspondingAsset.denom_units.reduce((prev: DenomUnit, current:DenomUnit) => {
             return (prev.exponent > current.exponent) ? prev : current;

--- a/src/modules/ibc.ts
+++ b/src/modules/ibc.ts
@@ -181,6 +181,7 @@ export class IBCModule extends BaseModule {
       return chainData.chain_name.includes(bridgeChainName.toLowerCase()) || chainData.chain_id.includes(bridgeChainName.toLowerCase());
     });
 
+    const defaultChainInfo = IBCUtils.EmbedChainInfos[chainId];
     if (selectedChainData) {
       try {
         const chainInfoResponse = await fetch(`https://raw.githubusercontent.com/cosmos/chain-registry/master/${selectedChainData.chain_name}/chain.json`);
@@ -253,8 +254,8 @@ export class IBCModule extends BaseModule {
         });
         
         return {
-          rpc: chainInfoJson.apis.rpc[0].address,
-          rest: chainInfoJson.apis.rest[0].address,
+          rpc: defaultChainInfo.rpc ?? chainInfoJson.apis.rpc[0].address,
+          rest: defaultChainInfo.rest ?? chainInfoJson.apis.rest[0].address,
           chainId: chainInfoJson.chain_id,
           chainName: chainInfoJson.chain_name,
           bip44: 
@@ -271,11 +272,11 @@ export class IBCModule extends BaseModule {
           ]
         };
     } catch(error){
-      return IBCUtils.EmbedChainInfos[chainId];
+      return defaultChainInfo;
     }
 
     } else {
-      return IBCUtils.EmbedChainInfos[chainId];
+      return defaultChainInfo;
     }
   }
 }

--- a/src/modules/ibc.ts
+++ b/src/modules/ibc.ts
@@ -178,22 +178,16 @@ export class IBCModule extends BaseModule {
 
   async getAssembledChainInfo(chainsData: ChainRegistryItem[], chainId: string, bridgeChainName: string): Promise<ChainInfo | undefined> {
     const selectedChainData = chainsData.find((chainData: ChainRegistryItem) => {
-
-      const d = chainData.chain_name.includes(bridgeChainName.toLowerCase()) || chainData.chain_id.includes(bridgeChainName.toLowerCase())
-
       return chainData.chain_name.includes(bridgeChainName.toLowerCase()) || chainData.chain_id.includes(bridgeChainName.toLowerCase());
     });
 
     if (selectedChainData) {
-
-
       try {
-        
-      const chainInfoResponse = await fetch(`https://raw.githubusercontent.com/cosmos/chain-registry/master/${selectedChainData.chain_name}/chain.json`);
-      const chainInfoJson = await chainInfoResponse.json();
-      const chainAssetListResponse = await fetch(`https://raw.githubusercontent.com/cosmos/chain-registry/master/${selectedChainData.chain_name}/assetlist.json`);
-      const assetListJson = await chainAssetListResponse.json();
-      const features: string[] = [];
+        const chainInfoResponse = await fetch(`https://raw.githubusercontent.com/cosmos/chain-registry/master/${selectedChainData.chain_name}/chain.json`);
+        const chainInfoJson = await chainInfoResponse.json();
+        const chainAssetListResponse = await fetch(`https://raw.githubusercontent.com/cosmos/chain-registry/master/${selectedChainData.chain_name}/assetlist.json`);
+        const assetListJson = await chainAssetListResponse.json();
+        const features: string[] = [];
       if (selectedChainData.cosmwasm_enabled) {
         features.push("cosmwasm");
       }

--- a/src/modules/ibc.ts
+++ b/src/modules/ibc.ts
@@ -167,7 +167,12 @@ export class IBCModule extends BaseModule {
 
   async getChainInfo(chainName: string): Promise<ChainInfo | undefined> {
     if (!chainName) return undefined
-    const chainInfoResponse = await fetch(`https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/master/cosmos/${chainName}.json`);
+    const chainInfoResponse = await fetch(`https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/master/cosmos/${chainName}.json`)
+    if (!chainInfoResponse.ok) {
+      if (chainInfoResponse.status === 404){
+        return undefined;
+      } 
+    }
     const chainInfoJson = await chainInfoResponse.json();
     return chainInfoJson as ChainInfo;
   }

--- a/src/modules/ibc.ts
+++ b/src/modules/ibc.ts
@@ -193,7 +193,8 @@ export class IBCModule extends BaseModule {
         }
 
         // Extract the staking currency denomination from chainInfoJson (min. denom)
-        const stakingCurrencyDenom = chainInfoJson['staking']['staking_tokens'][0]['denom'];
+        const stakingCurrencyDenom = chainInfoJson.staking.staking_tokens?.[0]?.denom || '';
+
         
         // Find the asset that matches the stakingCurrencyDenom
         const stakingAsset = assetListJson.assets.find((asset: Asset) => {
@@ -209,7 +210,7 @@ export class IBCModule extends BaseModule {
           coinDenom: maxExponentDenomUnit.denom.toUpperCase(),
           coinMinimalDenom: stakingCurrencyDenom,
           coinDecimals: maxExponentDenomUnit.exponent,
-          coinGeckoId: stakingAsset.coingecko_id,
+          coinGeckoId: stakingAsset?.coingecko_id ?? '',
         };
 
 
@@ -231,7 +232,7 @@ export class IBCModule extends BaseModule {
           // Find the corresponding asset for the fee token
           const correspondingAsset = assetListJson.assets.find((asset: Asset) => asset.base === feeToken.denom);
           if (!correspondingAsset) {
-            throw new Error(`No corresponding asset found for fee token denom: ${feeToken.denom}`);
+            return IBCUtils.EmbedChainInfos[chainId];
           }
           // Find the denom_unit with the maximum exponent
           const maxExponentDenomUnit = correspondingAsset.denom_units.reduce((prev: DenomUnit, current:DenomUnit) => {
@@ -251,23 +252,23 @@ export class IBCModule extends BaseModule {
         });
         
         return {
-          rpc: chainInfoJson['apis']['rpc'][0]['address'],
-          rest: chainInfoJson['apis']['rest'][0]['address'],
-          chainId: chainInfoJson['chain_id'],
-          chainName: chainInfoJson['chain_name'],
+          rpc: chainInfoJson.apis.rpc[0].address,
+          rest: chainInfoJson.apis.rest[0].address,
+          chainId: chainInfoJson.chain_id,
+          chainName: chainInfoJson.chain_name,
           bip44: 
           {
-            coinType: chainInfoJson['slip44']
+            coinType: chainInfoJson.slip44
           },
-          bech32Config:  IBCAddress.defaultBech32Config(chainInfoJson['bech32_prefix']) ,
+          bech32Config: IBCAddress.defaultBech32Config(chainInfoJson.bech32_prefix),
           stakeCurrency: stakeCurrency,
           currencies: currencies,
           feeCurrencies: feeCurrencies,
           features: [
             "ibc-transfer",
             "ibc-go"
-        ]
-        }
+          ]
+        };
     } catch(error){
       return IBCUtils.EmbedChainInfos[chainId];
     }

--- a/src/modules/ibc.ts
+++ b/src/modules/ibc.ts
@@ -188,68 +188,68 @@ export class IBCModule extends BaseModule {
         const chainAssetListResponse = await fetch(`https://raw.githubusercontent.com/cosmos/chain-registry/master/${selectedChainData.chain_name}/assetlist.json`);
         const assetListJson = await chainAssetListResponse.json();
         const features: string[] = [];
-      if (selectedChainData.cosmwasm_enabled) {
-        features.push("cosmwasm");
-      }
-
-      // Extract the staking currency denomination from chainInfoJson (min. denom)
-      const stakingCurrencyDenom = chainInfoJson['staking']['staking_tokens'][0]['denom'];
-      
-      // Find the asset that matches the stakingCurrencyDenom
-      const stakingAsset = assetListJson.assets.find((asset: Asset) => {
-        return asset.denom_units.some((unit: any) => unit.denom === stakingCurrencyDenom);
-      });
-
-      // Find the highest denom unit
-      const maxExponentDenomUnit = stakingAsset.denom_units.reduce((prev: DenomUnit, current: DenomUnit) => {
-        return (prev.exponent > current.exponent) ? prev : current;
-      });
-
-      let stakeCurrency: Currency = {
-        coinDenom: maxExponentDenomUnit.denom.toUpperCase(),
-        coinMinimalDenom: stakingCurrencyDenom,
-        coinDecimals: maxExponentDenomUnit.exponent,
-        coinGeckoId: stakingAsset.coingecko_id,
-      };
-
-
-      const currencies = assetListJson.assets.map((asset: Asset) => {
-        // Find the denom_unit with the maximum exponent
-        const maxExponentDenomUnit = asset.denom_units.reduce((prev, current) => {
-          return (prev.exponent > current.exponent) ? prev : current;
-        });
-        return {
-          coinDenom: maxExponentDenomUnit.denom.toUpperCase(),
-          coinMinimalDenom: asset.base,
-          coinDecimals: maxExponentDenomUnit.exponent,
-          coinGeckoId: asset.coingecko_id,
-        };
-      });
-      
-
-      const feeCurrencies = chainInfoJson.fees.fee_tokens.map((feeToken: FeeToken) => {
-        // Find the corresponding asset for the fee token
-        const correspondingAsset = assetListJson.assets.find((asset: Asset) => asset.base === feeToken.denom);
-        if (!correspondingAsset) {
-          throw new Error(`No corresponding asset found for fee token denom: ${feeToken.denom}`);
+        if (selectedChainData.cosmwasm_enabled) {
+          features.push("cosmwasm");
         }
-        // Find the denom_unit with the maximum exponent
-        const maxExponentDenomUnit = correspondingAsset.denom_units.reduce((prev: DenomUnit, current:DenomUnit) => {
+
+        // Extract the staking currency denomination from chainInfoJson (min. denom)
+        const stakingCurrencyDenom = chainInfoJson['staking']['staking_tokens'][0]['denom'];
+        
+        // Find the asset that matches the stakingCurrencyDenom
+        const stakingAsset = assetListJson.assets.find((asset: Asset) => {
+          return asset.denom_units.some((unit: any) => unit.denom === stakingCurrencyDenom);
+        });
+
+        // Find the highest denom unit
+        const maxExponentDenomUnit = stakingAsset.denom_units.reduce((prev: DenomUnit, current: DenomUnit) => {
           return (prev.exponent > current.exponent) ? prev : current;
         });
-        return {
+
+        let stakeCurrency: Currency = {
           coinDenom: maxExponentDenomUnit.denom.toUpperCase(),
-          coinMinimalDenom: feeToken.denom,
+          coinMinimalDenom: stakingCurrencyDenom,
           coinDecimals: maxExponentDenomUnit.exponent,
-          coinGeckoId: correspondingAsset.coingecko_id,
-          gasPriceStep: {
-            low: feeToken.low_gas_price,
-            average: feeToken.average_gas_price,
-            high: feeToken.high_gas_price,
-          }
+          coinGeckoId: stakingAsset.coingecko_id,
         };
-      });
-      
+
+
+        const currencies = assetListJson.assets.map((asset: Asset) => {
+          // Find the denom_unit with the maximum exponent
+          const maxExponentDenomUnit = asset.denom_units.reduce((prev, current) => {
+            return (prev.exponent > current.exponent) ? prev : current;
+          });
+          return {
+            coinDenom: maxExponentDenomUnit.denom.toUpperCase(),
+            coinMinimalDenom: asset.base,
+            coinDecimals: maxExponentDenomUnit.exponent,
+            coinGeckoId: asset.coingecko_id,
+          };
+        });
+        
+
+        const feeCurrencies = chainInfoJson.fees.fee_tokens.map((feeToken: FeeToken) => {
+          // Find the corresponding asset for the fee token
+          const correspondingAsset = assetListJson.assets.find((asset: Asset) => asset.base === feeToken.denom);
+          if (!correspondingAsset) {
+            throw new Error(`No corresponding asset found for fee token denom: ${feeToken.denom}`);
+          }
+          // Find the denom_unit with the maximum exponent
+          const maxExponentDenomUnit = correspondingAsset.denom_units.reduce((prev: DenomUnit, current:DenomUnit) => {
+            return (prev.exponent > current.exponent) ? prev : current;
+          });
+          return {
+            coinDenom: maxExponentDenomUnit.denom.toUpperCase(),
+            coinMinimalDenom: feeToken.denom,
+            coinDecimals: maxExponentDenomUnit.exponent,
+            coinGeckoId: correspondingAsset.coingecko_id,
+            gasPriceStep: {
+              low: feeToken.low_gas_price,
+              average: feeToken.average_gas_price,
+              high: feeToken.high_gas_price,
+            }
+          };
+        });
+        
         return {
           rpc: chainInfoJson['apis']['rpc'][0]['address'],
           rest: chainInfoJson['apis']['rest'][0]['address'],
@@ -263,12 +263,11 @@ export class IBCModule extends BaseModule {
           stakeCurrency: stakeCurrency,
           currencies: currencies,
           feeCurrencies: feeCurrencies,
-
           features: [
             "ibc-transfer",
             "ibc-go"
         ]
-     }
+        }
     } catch(error){
       return IBCUtils.EmbedChainInfos[chainId];
     }


### PR DESCRIPTION
Currently, chain info is queried dynamically from `chainapsis/keplr-chain-registry`. However there are certain chains that are not registered, hence this chain info needs to be retrieved from `cosmos/chain-registry`. 