### PR TITLE
Add denomTraces parameter to getChainInfoMap function

### DIFF
--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -78,8 +78,10 @@ class TokenClient {
 
     // non-blocking reload
     try {
-      this.reloadDenomTraces();
-      this.reloadDenomGeckoMap().finally(() => this.reloadUSDValues());
+      await Promise.allSettled([
+        this.reloadDenomTraces(),
+        this.reloadDenomGeckoMap().finally(() => this.reloadUSDValues())
+      ]);
     } catch (error) {
       console.error("failed to reload usd values");
       console.error(error);

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -78,10 +78,8 @@ class TokenClient {
 
     // non-blocking reload
     try {
-      await Promise.allSettled([
-        this.reloadDenomTraces(),
-        this.reloadDenomGeckoMap().finally(() => this.reloadUSDValues())
-      ]);
+      this.reloadDenomTraces();
+      this.reloadDenomGeckoMap().finally(() => this.reloadUSDValues());
     } catch (error) {
       console.error("failed to reload usd values");
       console.error(error);

--- a/src/modules/ibc.ts
+++ b/src/modules/ibc.ts
@@ -79,10 +79,10 @@ export class IBCModule extends BaseModule {
     );
   }
 
-  async getChainInfoMap(): Promise<TypeUtils.SimpleMap<ExtendedChainInfo>> {
+  async getChainInfoMap(denomTraces?: TypeUtils.SimpleMap<DenomTraceExtended>): Promise<TypeUtils.SimpleMap<ExtendedChainInfo>> {
     const tokenClient = this.sdkProvider.getTokenClient();
     const ibcBridges = tokenClient.bridges.ibc;
-    const denomTracesArr = Object.values(tokenClient.denomTraces);
+    const denomTracesArr = Object.values(denomTraces ?? tokenClient.denomTraces);
     const chainsResponse = await fetch(`https://chains.cosmos.directory/`);
     const chainsData = (await chainsResponse.json() as CosmosChainsObj);
     const chainInfoMap: TypeUtils.SimpleMap<ExtendedChainInfo> = {};


### PR DESCRIPTION
`getChainInfoMap` now optionally receive denomTraces as a parameter, allowing the function to skip the fetching step when denomTraces is already available.

In the context of the Demex sagas, denomTraces are queried and can be passed in as an argument to getChainInfoMap (resolves issue of inconsistent data state resulting in SWTH deposit form not loading)