### PR TITLE
update feeQuote api to include fee_denoms as an optional body

### DIFF
--- a/src/clients/HydrogenClient.ts
+++ b/src/clients/HydrogenClient.ts
@@ -13,7 +13,7 @@ import {
   GetTransfersResponse,
   RelaysResponse,
 } from "../hydrogen";
-import { GetFeeQuoteRequest, GetFeeQuoteRequestBody, GetFeeQuoteResponse } from "@carbon-sdk/hydrogen/feeQuote";
+import { GetFeeQuoteRequest, GetFeeQuoteResponse } from "@carbon-sdk/hydrogen/feeQuote";
 import TokenClient from './TokenClient'
 
 export const HydrogenEndpoints = {
@@ -253,7 +253,7 @@ class HydrogenClient {
     };
   }
 
-  async getFeeQuote(req: GetFeeQuoteRequest, blockchain: BlockchainUtils.Blockchain | BlockchainUtils.BlockchainV2 | undefined = undefined, version = "V1", body: GetFeeQuoteRequestBody = {}): Promise<GetFeeQuoteResponse> {
+  async getFeeQuote(req: GetFeeQuoteRequest, blockchain: BlockchainUtils.Blockchain | BlockchainUtils.BlockchainV2 | undefined = undefined, version = "V1"): Promise<GetFeeQuoteResponse> {
     this.checkState();
     const request = this.apiManager.path(
       "fee_quote",
@@ -262,7 +262,7 @@ class HydrogenClient {
         ...req,
       }
     );
-    const response = await request.post({ body });
+    const response = await request.post({ body: { fee_denoms: req.fee_denoms }});
     const result = response.data;
 
     return version === "V1" ? formatFeeQuote(result) : this.formatFeeQuoteV2(result, blockchain!);

--- a/src/clients/HydrogenClient.ts
+++ b/src/clients/HydrogenClient.ts
@@ -13,7 +13,7 @@ import {
   GetTransfersResponse,
   RelaysResponse,
 } from "../hydrogen";
-import { FeeQuote, GetFeeQuoteRequest, GetFeeQuoteResponse } from "@carbon-sdk/hydrogen/feeQuote";
+import { FeeQuote, GetFeeQuoteRequest, GetFeeQuoteRequestBody, GetFeeQuoteResponse } from "@carbon-sdk/hydrogen/feeQuote";
 import TokenClient from './TokenClient'
 
 export const HydrogenEndpoints = {
@@ -253,7 +253,7 @@ class HydrogenClient {
     };
   }
 
-  async getFeeQuote(req: GetFeeQuoteRequest, blockchain: BlockchainUtils.Blockchain | BlockchainUtils.BlockchainV2 | undefined = undefined, version = "V1"): Promise<GetFeeQuoteResponse> {
+  async getFeeQuote(req: GetFeeQuoteRequest, blockchain: BlockchainUtils.Blockchain | BlockchainUtils.BlockchainV2 | undefined = undefined, version = "V1", body: GetFeeQuoteRequestBody = {}): Promise<GetFeeQuoteResponse> {
     this.checkState();
     const request = this.apiManager.path(
       "fee_quote",
@@ -262,7 +262,7 @@ class HydrogenClient {
         ...req,
       }
     );
-    const response = await request.get();
+    const response = await request.post({ body });
     const result = response.data;
 
     return version === "V1" ? formatFeeQuote(result) : this.formatFeeQuoteV2(result, blockchain!);

--- a/src/clients/HydrogenClient.ts
+++ b/src/clients/HydrogenClient.ts
@@ -13,7 +13,7 @@ import {
   GetTransfersResponse,
   RelaysResponse,
 } from "../hydrogen";
-import { FeeQuote, GetFeeQuoteRequest, GetFeeQuoteRequestBody, GetFeeQuoteResponse } from "@carbon-sdk/hydrogen/feeQuote";
+import { GetFeeQuoteRequest, GetFeeQuoteRequestBody, GetFeeQuoteResponse } from "@carbon-sdk/hydrogen/feeQuote";
 import TokenClient from './TokenClient'
 
 export const HydrogenEndpoints = {
@@ -88,7 +88,7 @@ const formatChainEvent = (value: any): ChainTransaction | null => {
   } as ChainTransaction;
 };
 
-const formatFeeQuote = (value: any): FeeQuote => {
+const formatFeeQuote = (value: any): GetFeeQuoteResponse => {
   if (typeof value !== "object") return value;
   return {
     ...value,
@@ -178,7 +178,7 @@ class HydrogenClient {
     } as ChainTransaction;
   };
   
-  public formatFeeQuoteV2 = (value: any, blockchain: BlockchainUtils.BlockchainV2): FeeQuote => {
+  public formatFeeQuoteV2 = (value: any, blockchain: BlockchainUtils.BlockchainV2): GetFeeQuoteResponse => {
     if (typeof value !== "object") return value;
     return {
       ...value,

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -26,6 +26,7 @@ import InsightsQueryClient from "./InsightsQueryClient";
 import { QueryChannelsResponse } from "@carbon-sdk/codec/ibc/core/channel/v1/query";
 import { QueryConnectionsResponse } from "@carbon-sdk/codec/ibc/core/connection/v1/query";
 import { QueryClientStatesResponse } from "@carbon-sdk/codec/ibc/core/client/v1/query";
+import { json } from "stream/consumers";
 
 export interface DenomTraceExtended extends DenomTrace {
   token?: Token;
@@ -182,7 +183,14 @@ class TokenClient {
   public async getFeeInfo(denom: string): Promise<GetFeeQuoteResponse> {
     const config = this.configProvider.getConfig();
     const url = `${config.hydrogenUrl}/fee_quote?token_denom=${denom}`;
-    const result = await fetch(url).then((res) => res.json());
+    const requestOptions = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({})
+    }
+    const result = await FetchUtils.fetch(url, requestOptions).then((res) => res.json());
 
     return result as GetFeeQuoteResponse;
   }

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -10,7 +10,7 @@ import {
 } from "@carbon-sdk/constant";
 import { cibtIbcTokenRegex, ibcTokenRegex, ibcWhitelist, swthChannels, cosmBridgeRegex } from "@carbon-sdk/constant/ibc";
 import { publicRpcNodes } from "@carbon-sdk/constant/network";
-import { FeeQuote } from "@carbon-sdk/hydrogen/feeQuote";
+import { GetFeeQuoteResponse } from "@carbon-sdk/hydrogen/feeQuote";
 import { BlockchainUtils, FetchUtils, IBCUtils, NumberUtils, TypeUtils } from "@carbon-sdk/util";
 import { BlockchainV2, BridgeMap, BRIDGE_IDS, IbcBridge, PolyNetworkBridge, isIbcBridge } from '@carbon-sdk/util/blockchain';
 import { bnOrZero, BN_ONE, BN_ZERO } from "@carbon-sdk/util/number";
@@ -179,12 +179,12 @@ class TokenClient {
     return this.poolTokens[denom] ?? this.cdpTokens[denom] ?? this.tokens[denom];
   }
 
-  public async getFeeInfo(denom: string): Promise<FeeQuote> {
+  public async getFeeInfo(denom: string): Promise<GetFeeQuoteResponse> {
     const config = this.configProvider.getConfig();
     const url = `${config.hydrogenUrl}/fee_quote?token_denom=${denom}`;
     const result = await fetch(url).then((res) => res.json());
 
-    return result as FeeQuote;
+    return result as GetFeeQuoteResponse;
   }
 
   public getTokenName(denom: string, overrideMap?: TypeUtils.SimpleMap<string>): string {

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -26,7 +26,6 @@ import InsightsQueryClient from "./InsightsQueryClient";
 import { QueryChannelsResponse } from "@carbon-sdk/codec/ibc/core/channel/v1/query";
 import { QueryConnectionsResponse } from "@carbon-sdk/codec/ibc/core/connection/v1/query";
 import { QueryClientStatesResponse } from "@carbon-sdk/codec/ibc/core/client/v1/query";
-import { json } from "stream/consumers";
 
 export interface DenomTraceExtended extends DenomTrace {
   token?: Token;

--- a/src/hydrogen/feeQuote.ts
+++ b/src/hydrogen/feeQuote.ts
@@ -2,10 +2,7 @@ import dayjs from "dayjs";
 
 export interface GetFeeQuoteRequest {
   token_denom: string;
-}
-
-export interface GetFeeQuoteRequestBody {
-  fee_denoms?: string[];
+  fee_denoms?: string[]
 }
 
 export interface GetFeeQuoteResponse {
@@ -17,7 +14,7 @@ export interface GetFeeQuoteResponse {
   withdrawal_fee: string;
   created_at: dayjs.Dayjs;
   expires_at: dayjs.Dayjs;
-  other_token_fees?: FeeDenomResponse[] | undefined
+  other_token_fees?: FeeDenomResponse[]
 }
 
 interface FeeDenomResponse {

--- a/src/hydrogen/feeQuote.ts
+++ b/src/hydrogen/feeQuote.ts
@@ -4,6 +4,10 @@ export interface GetFeeQuoteRequest {
   token_denom: string;
 }
 
+export interface GetFeeQuoteRequestBody {
+  fee_denoms?: string[];
+}
+
 export interface GetFeeQuoteResponse {
   id: number;
   token_denom: string;

--- a/src/hydrogen/feeQuote.ts
+++ b/src/hydrogen/feeQuote.ts
@@ -17,15 +17,12 @@ export interface GetFeeQuoteResponse {
   withdrawal_fee: string;
   created_at: dayjs.Dayjs;
   expires_at: dayjs.Dayjs;
+  other_token_fees?: FeeDenomResponse[] | undefined
 }
 
-export interface FeeQuote {
-  id: number;
-  token_denom: string;
-  blockchain: string;
-  create_wallet_fee: string;
-  deposit_fee: string;
-  withdrawal_fee: string;
-  created_at: dayjs.Dayjs;
-  expires_at: dayjs.Dayjs;
+interface FeeDenomResponse {
+  denom: string,
+  withdrawal_fee: string,
+  deposit_fee: string,
+  create_wallet_fee: string
 }


### PR DESCRIPTION
change feeQuote api to accept an optional request body of:

{
  `fee_denoms`: `String[]`
}

where each input `fee_denom` provided will output the converted fees in the exchange rate of said input denom

