### PR TITLE
add include_tx field in hydrogen getTransfersQuery

### DIFF
--- a/src/hydrogen/transfer.ts
+++ b/src/hydrogen/transfer.ts
@@ -13,6 +13,7 @@ export interface GetTransfersRequest {
   to_asset?: string;
   offset?: number;
   limit?: number;
+  include_tx?: boolean;
 }
 
 export interface GetTransfersResponse {


### PR DESCRIPTION
fix bug where `getTransfersRequest`, which defines the query params for the `https://hydrogen-api.carbon.network/transfer_payloads` endpoint, was missing the `include_tx` field, which didnt allow the client to get detailed transfers that included the events and relays