### PR TITLE
Remove deprecated msg from getDetailedTransfers function

### DIFF
--- a/src/clients/HydrogenClient.ts
+++ b/src/clients/HydrogenClient.ts
@@ -211,7 +211,6 @@ class HydrogenClient {
     };
   }
 
-  /** @deprecated getDetailedTransfers function is deprecated, please use getTransfers instead */
   async getDetailedTransfers(req: GetTransfersRequest, version = "V1"): Promise<GetDetailedTransfersResponse> {
     this.checkState();
     const request = this.apiManager.path(


### PR DESCRIPTION
Remove deprecated msg from `getDetailedTransfers` function, which is wrong (i.e. function is not deprecated)