### PR TITLE
Add provider agent to withLedger function

### DIFF
--- a/src/constant/walletProvider.ts
+++ b/src/constant/walletProvider.ts
@@ -5,5 +5,6 @@ export enum ProviderAgent {
   LeapExtension = "leap-extension",
   MetamaskExtension = "metamask-extension",
   // For legacy metamask
-  Metamask = "metamask"
+  Metamask = "metamask",
+  Web3Auth = "web3auth",
 }

--- a/src/wallet/CarbonWallet.ts
+++ b/src/wallet/CarbonWallet.ts
@@ -259,8 +259,8 @@ export class CarbonWallet {
   public static withLedger(cosmosLedger: CosmosLedger, publicKeyBase64: string, opts: Omit<CarbonWalletInitOpts, "signer"> = {}) {
     const signer = new CarbonLedgerSigner(cosmosLedger);
     const wallet = CarbonWallet.withSigner(signer, publicKeyBase64, {
+      providerAgent: ProviderAgent.Ledger,
       ...opts,
-      providerAgent: ProviderAgent.Ledger
     });
     return wallet;
   }
@@ -278,8 +278,8 @@ export class CarbonWallet {
     const publicKeyBase64 = Buffer.from(keplrKey.pubKey).toString("base64");
 
     const wallet = CarbonWallet.withSigner(signer, publicKeyBase64, {
-      ...opts,
       providerAgent: ProviderAgent.KeplrExtension,
+      ...opts,
     });
     return wallet;
   }
@@ -289,8 +289,8 @@ export class CarbonWallet {
     const publicKeyBase64 = Buffer.from(leapKey.pubKey).toString("base64");
 
     const wallet = CarbonWallet.withSigner(signer, publicKeyBase64, {
-      ...opts,
       providerAgent: ProviderAgent.LeapExtension,
+      ...opts,
     });
     return wallet;
   }
@@ -298,8 +298,8 @@ export class CarbonWallet {
   public static withMetamask(metamask: MetaMask, evmChainId: string, compressedPubKeyBase64: string, addressOptions: SWTHAddressOptions, opts: Omit<CarbonWalletInitOpts, "signer"> = {}) {
     const signer = MetaMask.createMetamaskSigner(metamask, evmChainId, compressedPubKeyBase64, addressOptions);
     const wallet = CarbonWallet.withSigner(signer, compressedPubKeyBase64, {
-      ...opts,
       providerAgent: ProviderAgent.MetamaskExtension,
+      ...opts,
     });
     return wallet;
   }

--- a/src/wallet/CarbonWallet.ts
+++ b/src/wallet/CarbonWallet.ts
@@ -258,7 +258,10 @@ export class CarbonWallet {
 
   public static withLedger(cosmosLedger: CosmosLedger, publicKeyBase64: string, opts: Omit<CarbonWalletInitOpts, "signer"> = {}) {
     const signer = new CarbonLedgerSigner(cosmosLedger);
-    const wallet = CarbonWallet.withSigner(signer, publicKeyBase64, opts);
+    const wallet = CarbonWallet.withSigner(signer, publicKeyBase64, {
+      ...opts,
+      providerAgent: ProviderAgent.Ledger
+    });
     return wallet;
   }
 


### PR DESCRIPTION
Card related to:  [Carbon Core <> Carbon EVM bridge on Demex ](https://www.notion.so/switcheo/Carbon-Core-Carbon-EVM-bridge-on-Demex-ff8ed24ca08542bf8103178a96bb123e)

Need this to check whether the wallet is Ledger or not for the carbon token bridge implementation. Currently providerAgent is undefined when connecting with Ledger. Used just to determine which Image to show when signing.
Example: Keplr/Metamask etc... 

![image](https://github.com/Switcheo/carbon-js-sdk/assets/47170358/1e025b6c-9165-45ef-813b-871c11b91e00)
^ Example of image

Unless if there's another way to check if connected wallet is Ledger? Then I can do that instead.