### PR TITLE
changed liquidityPoolModule typeUrl to MsgLiquidityPoolCreatePool

### DIFF
--- a/src/modules/liquiditypool.ts
+++ b/src/modules/liquiditypool.ts
@@ -23,7 +23,7 @@ export class LiquidityPoolModule extends BaseModule {
 
     return await wallet.sendTx(
       {
-        typeUrl: CarbonTx.Types.MsgCreatePool,
+        typeUrl: CarbonTx.Types.MsgLiquiditypoolCreatePool,
         value,
       },
       opts


### PR DESCRIPTION
I'm investigating broken pool routes on the carbon-bot and discovered that on the SDK both the Perps pool and spot pool are using the same MsgCreatePool. 

When the carbon-bot tries to create a spot pool, the SDK is expecting perp pool parameters. 

Is the liquiditypool meant to have a typeUrl of MsgLiquiditypoolCreatePool instead?

<img width="982" alt="LP" src="https://github.com/Switcheo/carbon-js-sdk/assets/65338691/fce985d3-2502-4700-a498-bad48c7ca393">

<img width="912" alt="PP" src="https://github.com/Switcheo/carbon-js-sdk/assets/65338691/2cb537c2-ac23-47cc-99ae-0d2691cf92fe">
