### PR TITLE
correct js sdk to accept multiple blockchains for transfer_payloads api

### DIFF
--- a/src/hydrogen/transfer.ts
+++ b/src/hydrogen/transfer.ts
@@ -5,6 +5,7 @@ export interface GetTransfersRequest {
   bridging_blockchain?: string;
   source_blockchain?: string;
   destination_blockchain?: string;
+  blockchains?:string;
   address?: string;
   from_address?: string;
   to_address?: string;

--- a/src/hydrogen/transfer.ts
+++ b/src/hydrogen/transfer.ts
@@ -5,7 +5,7 @@ export interface GetTransfersRequest {
   bridging_blockchain?: string;
   source_blockchain?: string;
   destination_blockchain?: string;
-  blockchains?:string;
+  blockchains?: string;
   address?: string;
   from_address?: string;
   to_address?: string;


### PR DESCRIPTION
- enable transfer_payloads api to take in multiple blockchains:
- Notion card: https://www.notion.so/switcheo/enable-transfer_payloads-api-to-take-in-multiple-blockchains-e145e69905b941938a2f61315101926b?pvs=4

In hydrogen, transfer_payloads api is structured to take in ```blockchains```:
```
"blockchains": {
      "type": "string",
      "description": "search multiple blockchains"
    },
```

updated sdk to take in multiple blockchains