### PR TITLE
Fix keplr connection on Carbon Testnet by removing EVM field on config

### DIFF
--- a/src/provider/keplr/KeplrAccount.ts
+++ b/src/provider/keplr/KeplrAccount.ts
@@ -187,6 +187,7 @@ class KeplrAccount {
   static async getChainInfo(configProvider: SDKProvider): Promise<ChainInfo> {
     const config = configProvider.getConfig();
     const bech32Prefix = config.Bech32Prefix;
+    const isMainnet = config.network === Network.MainNet;
 
     const chainId = config.chainId;
     const url = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/master/cosmos/carbon.json"
@@ -197,7 +198,7 @@ class KeplrAccount {
       console.warn(error)
     }
 
-    if (config.network === Network.MainNet && keplrChainInfo) {
+    if (isMainnet && keplrChainInfo) {
       if (keplrChainInfo.nodeProvider) {
         delete keplrChainInfo.nodeProvider;
       }
@@ -218,10 +219,12 @@ class KeplrAccount {
       rpc: config.tmRpcUrl,
       chainName: `Carbon (${config.network})`,
       chainId: chainId,
-      evm: {
-        chainId: Number(parseChainId(CarbonEvmChainIDs[config.network])),
-        rpc: config.evmJsonRpcUrl,
-      },
+      ...isMainnet && ({
+        evm: {
+          chainId: Number(parseChainId(CarbonEvmChainIDs[config.network])),
+          rpc: config.evmJsonRpcUrl,
+        },
+      }),
       bech32Config: {
         bech32PrefixAccAddr: `${bech32Prefix}`,
         bech32PrefixAccPub: `${bech32Prefix}pub`,


### PR DESCRIPTION
**Issue**
On the keplr suggest chain info config for Carbon, the [evm](https://github.com/Switcheo/carbon-js-sdk/blob/staging/src%2Fprovider%2Fkeplr%2FKeplrAccount.ts#L221-L224) field is only required on Carbon Mainnet at the moment. If added to the chainInfo config for Carbon Testnet or Devnet, it will cause the following error when user tries to connect wallet.
<img src="https://github.com/user-attachments/assets/3f821102-1bbf-4170-90f9-56349791dab5" alt="photo_6165578085332794429_x" width="420" />

**Solution**
When connecting to Carbon Testnet or Devnet, remove the `evm` field.