### PR TITLE
fix: parse number chain ids

### DIFF
--- a/src/clients/HydrogenClient.ts
+++ b/src/clients/HydrogenClient.ts
@@ -134,9 +134,9 @@ class HydrogenClient {
       ...value,
       created_at: formatDateField(value.created_at?.toString()),
       updated_at: formatDateField(value.updated_at?.toString()),
-      source_blockchain: this.tokenClient.getBlockchainV2FromIDs(value.from_chain_id, value.bridge_id),
+      source_blockchain: this.tokenClient.getBlockchainV2FromIDs(Number(value.from_chain_id), value.bridge_id),
       bridging_blockchain: getBridgeBlockchainFromId(value.bridge_id),
-      destination_blockchain: this.tokenClient.getBlockchainV2FromIDs(value.to_chain_id, value.bridge_id),
+      destination_blockchain: this.tokenClient.getBlockchainV2FromIDs(Number(value.to_chain_id), value.bridge_id),
       source_event: this.formatChainEventV2(value.source_event, value.source_blockchain ?? ''),
       bridging_event: this.formatChainEventV2(value.bridging_event, getBridgeBlockchainFromId(value.bridge_id)),
       destination_event: this.formatChainEventV2(value.destination_event, value.destination_blockchain ?? ''),
@@ -146,8 +146,8 @@ class HydrogenClient {
 
   public formatCrossChainTransferDetailedV2 = (value: any): CrossChainTransferDetailed => {
     if (!value || typeof value !== "object") return value;
-    const source_blockchain = this.tokenClient.getBlockchainV2FromIDs(value.from_chain_id, value.bridge_id)
-    const destination_blockchain = this.tokenClient.getBlockchainV2FromIDs(value.to_chain_id, value.bridge_id)
+    const source_blockchain = this.tokenClient.getBlockchainV2FromIDs(Number(value.from_chain_id), value.bridge_id)
+    const destination_blockchain = this.tokenClient.getBlockchainV2FromIDs(Number(value.to_chain_id), value.bridge_id)
     const bridging_blockchain = getBridgeBlockchainFromId(value.bridge_id)
     return {
       ...this.formatCrossChainTransferV2(value),


### PR DESCRIPTION
https://www.notion.so/switcheo/Edit-carbon-js-sdk-to-parse-chain_id-regardless-of-type-1c0135fd728b457a986686b8762e247c

![c6f33620-a982-49e3-b659-8bdbae60a37b](https://github.com/user-attachments/assets/8b760388-a2c4-4c7d-bca1-3fd6465d1459)
![photo_6226354333587455831_y](https://github.com/user-attachments/assets/ba30e8ff-964f-470f-9ee6-5a86f470f103)

The response from hydrogen api, sometimes from_chain_id and to_chain_id are numbers; other times they are strings.
From the SDK, we expected them to be of type number. So, when comparing a number with a string, the result is false.

Then it leads to this issue
![photo_6208386247710326262_y](https://github.com/user-attachments/assets/7dd1ec9b-22a6-4221-8a78-f743f6f3d411)

The Hydrogen API has updated its API to ensure consistent response types, fixing the issue. However, Ivan wants to verify that we are parsing the correct type on carbon sdk
