### PR TITLE
chore: configure Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Singapore"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+    open-pull-requests-limit: 2
+    groups:
+      routine-javascript-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "build"
+      include: "scope"


### PR DESCRIPTION
## What changed

- Added a root npm/Yarn Dependabot entry so routine dependency maintenance is automated for the project’s `package.json` and `yarn.lock`.
- Grouped minor and patch updates to reduce PR noise while leaving major upgrades isolated for deliberate review.
- Limited concurrent update PRs to two and added release cooldowns to avoid immediately adopting newly published versions.
- Added conventional dependency commit prefixes and dependency/ecosystem labels for easier triage.
- Omitted GitHub Actions updates because this repository currently has no workflow files.

## Verification

- Parsed `.github/dependabot.yml` successfully with PyYAML.
- Confirmed `git diff --check` passes.
- Confirmed no nested supported manifests require additional directory entries.