### PR TITLE
chore(deps): update decode-uri-component

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2433,9 +2433,9 @@ debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
     ms "2.1.2"
 
 decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 decode-uri-component@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
## Summary

Consolidates the one dependency update that remained relevant, compatible, and sufficiently auditable on current `staging`.

Only `yarn.lock` is changed; no application or compatibility code is included.

## Included update

- **Dependabot PR #220 equivalent — `decode-uri-component` `0.2.0` → `0.2.2`**
  - Transitive dependency through `query-string@7.0.1` and its `decode-uri-component@^0.2.0` range.
  - Fixes high-severity denial-of-service advisory [GHSA-w573-4hg7-7wgq](https://github.com/advisories/GHSA-w573-4hg7-7wgq) / CVE-2022-38900.
  - `0.2.1` is the first patched version; `0.2.2` adds a follow-up correctness fix.
  - `0.2.2` is the highest release satisfying the existing `^0.2.0` range.

## Skipped updates

- **PR #270 — `@sideway/formula` `3.0.0` → `3.0.1`**
  - `3.0.1` is a legitimate ReDoS fix, but the package no longer exists in current `staging`'s dependency graph.
  - Applying the stale PR would therefore be a no-op or reintroduce obsolete graph state.

- **PR #211 — `socket.io-parser` `3.3.2` → `3.3.3`**
  - The package is no longer present in current `staging`.
  - The proposed `3.3.3` target now has known vulnerabilities.
  - If this dependency returns on the `~3.3.0` line, it should be separately audited and updated to at least `3.3.5`.

## Security and supply-chain audit

For `decode-uri-component@0.2.2`:

- Canonical npm package and upstream repository remain controlled by Sam Verschueren.
- Publisher and sole maintainer remained unchanged across `0.2.0`–`0.2.2`.
- Published tarball SHA-1 and SHA-512/SRI match the lockfile exactly.
- Source/package changes are limited to safer malformed-URI tokenization and a follow-up correctness fix.
- No runtime dependencies were introduced.
- No install hooks, binaries, native code, network access, shell/subprocess execution, credential access, filesystem access, or obfuscation were found.
- GitHub advisories were reviewed; no advisory affecting `0.2.2` was found.

## Compatibility

- Remains CommonJS and retains its historical Node compatibility.
- Remains within the parent dependency's existing `^0.2.0` semver range.
- Newer `0.5.0` was intentionally not selected because it is outside that range and changes module/runtime requirements, including ESM and Node `>=14.16`.
- Base-relative diff is three insertions and three deletions in `yarn.lock` only.

## Validation

| Command/check | Result |
|---|---|
| Published tarball SHA-1 and SHA-512/SRI comparison | Passed — exact lockfile match |
| GitHub advisory review for `0.2.2` | Passed — none found |
| `corepack yarn install --frozen-lockfile --ignore-scripts --non-interactive` | Passed |
| `corepack yarn check --integrity --ignore-scripts` | Passed |
| Installed target-version check | Passed — `0.2.2` |
| URI-decoding regression smoke tests | Passed |
| `corepack yarn build` | Passed — ESLint, TypeScript, and `tsc-alias` |
| `git diff --check` | Passed |
| Base-relative changed-file scope | Passed — only `yarn.lock` |
| `corepack yarn test` | Blocked by a pre-existing repository issue described below |

## Blocked check

`corepack yarn test` compiles successfully but then attempts to execute missing `lib/test.js`. The same script is present on `origin/staging`, and neither the base nor this branch contains a tracked source file that generates `lib/test.js`. This is unrelated to the dependency update and is not evidence of dependency incompatibility.

## Residual risk

- This is a transitive lockfile-only update in an older dependency graph; the audit verifies the selected artifact and compatibility path but does not eliminate risk elsewhere in the repository's broader legacy dependency tree.
- No unrelated code was changed.
