### PR TITLE
fix: patch compatible HTTP dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@ledgerhq/hw-transport": "6.28.8",
     "@ledgerhq/hw-transport-webhid": "^6.20.0",
     "@ledgerhq/hw-transport-webusb": "^6.20.0",
-    "axios": "0.27.2",
+    "axios": "0.33.0",
     "bech32": "1.1.4",
     "bignumber.js": "^9.1.0",
     "bip32": "^2.0.6",

--- a/tests/direct-import-contracts.test.cjs
+++ b/tests/direct-import-contracts.test.cjs
@@ -23,7 +23,7 @@ const expectedDirectContracts = {
   "@cosmjs/utils": "0.32.4",
   "@ethersproject/abstract-signer": "5.7.0",
   "@ledgerhq/hw-transport": "6.28.8",
-  axios: "0.27.2",
+  axios: "0.33.0",
   bech32: "1.1.4",
   long: "4.0.0",
   protobufjs: "6.11.4",

--- a/tests/http-compatible-patches.test.cjs
+++ b/tests/http-compatible-patches.test.cjs
@@ -1,0 +1,146 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global Buffer, __dirname, require */
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const http = require("node:http");
+const path = require("node:path");
+const test = require("node:test");
+
+const projectRoot = path.resolve(__dirname, "..");
+const lockfile = fs.readFileSync(path.join(projectRoot, "yarn.lock"), "utf8");
+
+function lockedVersions(packageName) {
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const stanza = new RegExp(`^(?:${escaped})@[^\n]+:\\n(?:[ ]{2}[^\n]*\\n|[ ]{4}[^\n]*\\n)*`, "gm");
+  return [...lockfile.matchAll(stanza)]
+    .map((match) => match[0].match(/^[ ]{2}version "([^"]+)"$/m)?.[1])
+    .filter(Boolean)
+    .sort();
+}
+
+const expectedVersions = {
+  axios: ["0.21.1", "0.27.2", "0.33.0", "1.18.1"],
+  "follow-redirects": ["1.16.0"],
+  "form-data": ["3.0.5", "4.0.6"],
+};
+
+for (const [packageName, versions] of Object.entries(expectedVersions)) {
+  test(`${packageName} has the audited compatible lock targets`, () => {
+    assert.deepEqual(lockedVersions(packageName), versions);
+  });
+}
+
+function listen(server, host = "127.0.0.1") {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, host, () => resolve(server.address().port));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+test("the direct Axios contract preserves SDK POST, response, and interceptor behavior", async (context) => {
+  const axios = require("axios");
+  let receivedBody = "";
+  let receivedHeader;
+  const server = http.createServer((request, response) => {
+    receivedHeader = request.headers["x-sdk-interceptor"];
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      receivedBody += chunk;
+    });
+    request.on("end", () => {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ result: "jwt-token", order: ["server"] }));
+    });
+  });
+  const port = await listen(server);
+  context.after(() => close(server));
+
+  const client = axios.create();
+  client.interceptors.request.use((config) => {
+    config.headers["x-sdk-interceptor"] = "request";
+    return config;
+  });
+  client.interceptors.response.use((response) => {
+    response.data.order.push("response");
+    return response;
+  });
+
+  const response = await client.post(`http://127.0.0.1:${port}/auth`, {
+    grant_type: "refresh_token",
+    refresh_token: "local-test-token",
+  });
+
+  assert.equal(receivedHeader, "request");
+  assert.deepEqual(JSON.parse(receivedBody), {
+    grant_type: "refresh_token",
+    refresh_token: "local-test-token",
+  });
+  assert.equal(response.data.result, "jwt-token");
+  assert.deepEqual(response.data.order, ["server", "response"]);
+});
+
+test("the direct Axios contract preserves structured HTTP errors", async (context) => {
+  const axios = require("axios");
+  const server = http.createServer((_request, response) => {
+    response.writeHead(422, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: "invalid grant" }));
+  });
+  const port = await listen(server);
+  context.after(() => close(server));
+
+  await assert.rejects(axios.post(`http://127.0.0.1:${port}/auth`, {}), (error) => {
+    assert.equal(axios.isAxiosError(error), true);
+    assert.equal(error.code, "ERR_BAD_REQUEST");
+    assert.equal(error.response.status, 422);
+    assert.deepEqual(error.response.data, { error: "invalid grant" });
+    return true;
+  });
+});
+
+test("follow-redirects strips credentials on a cross-host redirect", async (context) => {
+  const { http: redirectingHttp } = require("follow-redirects");
+  let receivedHeaders;
+  const target = http.createServer((request, response) => {
+    receivedHeaders = request.headers;
+    response.end("ok");
+  });
+  const targetPort = await listen(target, "localhost");
+  context.after(() => close(target));
+
+  const redirect = http.createServer((_request, response) => {
+    response.writeHead(302, { location: `http://localhost:${targetPort}/target` });
+    response.end();
+  });
+  const redirectPort = await listen(redirect);
+  context.after(() => close(redirect));
+
+  await new Promise((resolve, reject) => {
+    const request = redirectingHttp.get(
+      `http://127.0.0.1:${redirectPort}/start`,
+      { headers: { authorization: "Bearer local-test-token", cookie: "session=local-test", "x-public": "kept" } },
+      (response) => {
+        response.resume();
+        response.once("end", resolve);
+      },
+    );
+    request.once("error", reject);
+  });
+
+  assert.equal(receivedHeaders.authorization, undefined);
+  assert.equal(receivedHeaders.cookie, undefined);
+  assert.equal(receivedHeaders["x-public"], "kept");
+});
+
+test("form-data escapes CRLF in multipart filenames", () => {
+  const FormData = require("form-data");
+  const form = new FormData();
+  form.append("payload", Buffer.from("safe"), { filename: "report\r\nX-Injected: yes.txt" });
+  const header = form._streams.find((stream) => typeof stream === "string");
+
+  assert.equal(header.includes("\r\nX-Injected: yes.txt"), false);
+  assert.match(header, /filename="report%0D%0AX-Injected: yes\.txt"/);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1498,6 +1498,13 @@ aes-js@3.0.0:
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
   integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 ajv@^6.14.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
@@ -1562,7 +1569,16 @@ axios@0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
-axios@0.27.2, axios@^0.27.2:
+axios@0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.33.0.tgz#91fc5e231db5b81ab6474c0a945a603c55601f6e"
+  integrity sha512-juz19g7B3UWT9r3+tgRFQf2Bdy6IKDVroiyuVOUrkILVKHpqHL++K1l8ybvfdEP9B/VE72vk8vllbnedVCm/og==
+  dependencies:
+    follow-redirects "^1.15.4"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
+
+axios@^0.27.2:
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
   integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
@@ -1571,13 +1587,14 @@ axios@0.27.2, axios@^0.27.2:
     form-data "^4.0.0"
 
 axios@^1.6.0:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
-  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.18.1.tgz#d63f9863bcd8938815c86f9e2abd380189d96dfe"
+  integrity sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
+    follow-redirects "^1.16.0"
+    form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
+    proxy-from-env "^2.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -1972,7 +1989,7 @@ dayjs@^1.10.5:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
   integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
 
-debug@^4, debug@^4.3.1, debug@^4.4.3:
+debug@4, debug@^4, debug@^4.3.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -2122,6 +2139,16 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
   dependencies:
     es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -2454,20 +2481,10 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
-follow-redirects@^1.10.0:
-  version "1.14.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
-  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
-
-follow-redirects@^1.14.9:
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
-
-follow-redirects@^1.15.6:
-  version "1.15.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+follow-redirects@^1.10.0, follow-redirects@^1.14.9, follow-redirects@^1.15.4, follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.5:
   version "0.3.5"
@@ -2477,22 +2494,26 @@ for-each@^0.3.5:
     is-callable "^1.2.7"
 
 form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.5.tgz#2ea3ec24f0dcb7e0262a11efb732031240ea8e9f"
+  integrity sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+form-data@^4.0.0, form-data@^4.0.4, form-data@^4.0.5:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 fsevents@~2.3.2:
   version "2.3.3"
@@ -2504,7 +2525,7 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-intrinsic@^1.2.4, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.4, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -2662,7 +2683,7 @@ hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7, hash.js@~1.1.7:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hasown@^2.0.2:
+hasown@^2.0.2, hasown@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
   integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
@@ -2682,6 +2703,14 @@ http-shutdown@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/http-shutdown/-/http-shutdown-1.2.2.tgz#41bc78fc767637c4c95179bc492f312c0ae64c5f"
   integrity sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 human-signals@^5.0.0:
   version "5.0.0"
@@ -3085,17 +3114,17 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
-mime-db@1.49.0:
-  version "1.49.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
-  integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12:
-  version "2.1.32"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.32.tgz#1d00e89e7de7fe02008db61001d9e02852670fd5"
-  integrity sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==
+mime-types@^2.1.35:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
-    mime-db "1.49.0"
+    mime-db "1.52.0"
 
 mime@^3.0.0:
   version "3.0.0"
@@ -3506,6 +3535,11 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 pstree.remy@^1.1.8:
   version "1.1.8"


### PR DESCRIPTION
## What changed

- Updates the SDK's exact direct Axios contract from `0.27.2` to audited `0.33.0`; `0.32.0` was not selected because it is already superseded by security fixes.
- Advances the compatible `axios@^1.6.0` path from `1.8.4` to audited `1.18.1`.
- Coalesces all compatible `follow-redirects` ranges at `1.16.0` and patches `form-data` to `3.0.5`/`4.0.6` without resolutions.
- Adds local HTTP regressions for the SDK's Axios POST/response/interceptor/error contracts, cross-host credential stripping, multipart filename escaping, and exact lock targets.

Stacked on #632 and intentionally targets `security/crypto-transitive-leaf-patches`.

## Supply-chain and compatibility audit

- Verified canonical npm existence, integrity/shasum, repository, license, engines, git heads, lifecycle scripts, and exact dependency changes for all selected artifacts.
- Selected artifacts add no install hooks. Axios `1.18.1` legitimately adds `https-proxy-agent@5.0.1` and `proxy-from-env@2.1.0`; FormData's patched lines add their small descriptor/tag and MIME closure. All graph changes were traced to these parents.
- `npm audit signatures`: 601 installed packages have verified signatures; 42 have attestations.
- Independent fail-closed review confirmed versions, selectors, cached tarball integrities, graph reachability, behavior tests, and Node 24 compatibility; no blockers.

## Advisory scope and blockers

This intentionally does **not** claim complete Axios closure:

- `axios@0.21.1` is exact-pinned by deprecated `secretjs@0.17.7`.
- `axios@0.27.2` remains under Keplr's `^0.27.2` range; caret semantics for a `0.x` minor reject `0.33.0`.

Overriding either would violate the owning package's contract. They require focused SecretJS/Keplr root migrations.

## Validation

Node `24.18.0`, Yarn `1.22.22`:

- scripts-disabled install + matching integrity check — passed
- clean frozen lifecycle-enabled install + integrity — passed
- `yarn lint` — passed
- `yarn test` — 77/77 passed
- `yarn build` — passed
- `npm pack --dry-run --json` — passed; 1,324 files
- lifecycle-enabled isolated packed consumer + package smoke — 6/6 passed
- direct secp256k1 prebuild probe — loaded audited Linux x64 glibc prebuild
- `npm audit signatures` — 601 verified signatures, 42 attestations
- `git diff --check` — passed
- credential-pattern scan — no findings; `gitleaks` unavailable

This stacked PR has no GitHub checks because the workflow is scoped to PRs targeting `staging`; the full equivalent validation ran locally.

## Residual risks

- The two legacy Axios copies above remain vulnerable until their owning root packages migrate.
- Axios `1.18.1` expands proxy support with an audited agent path; local behavior and packed-consumer checks passed, but no external proxy service was contacted.
- GitHub's live alert count remains based on the default branch until this stack lands.
