### PR TITLE
fix: patch compatible Ledger runtime leaves

### DIFF
--- a/tests/ledger-runtime-leaves.test.cjs
+++ b/tests/ledger-runtime-leaves.test.cjs
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global __dirname, require */
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const projectRoot = path.resolve(__dirname, "..");
+const lockfile = fs.readFileSync(path.join(projectRoot, "yarn.lock"), "utf8");
+
+function lockedVersions(packageName) {
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const quoted = packageName.startsWith("@");
+  const prefix = quoted ? `"${escaped}@` : `${escaped}@`;
+  const stanza = new RegExp(`^${prefix}[^\n]+:\\n(?:[ ]{2}[^\n]*\\n|[ ]{4}[^\n]*\\n)*`, "gm");
+  return [...lockfile.matchAll(stanza)]
+    .map((match) => match[0].match(/^[ ]{2}version "([^"]+)"$/m)?.[1])
+    .filter(Boolean)
+    .sort();
+}
+
+test("@babel/runtime has only the audited compatible lock target", () => {
+  assert.deepEqual(lockedVersions("@babel/runtime"), ["7.26.10"]);
+});
+
+test("semver has no vulnerable lock targets", () => {
+  assert.deepEqual(lockedVersions("semver"), ["7.6.2", "7.8.5"]);
+});
+
+test("Babel helpers used by Ledger packages preserve object and async behavior", async () => {
+  const extendsHelper = require("@babel/runtime/helpers/extends");
+  const asyncToGenerator = require("@babel/runtime/helpers/asyncToGenerator");
+  const merged = extendsHelper({}, { transport: "webusb" }, { transport: "webhid", app: "Carbon" });
+  const wrapped = asyncToGenerator(function* ledgerValue() {
+    return yield Promise.resolve(merged);
+  });
+
+  assert.deepEqual(merged, { transport: "webhid", app: "Carbon" });
+  await assert.doesNotReject(async () => assert.deepEqual(await wrapped(), merged));
+});
+
+test("semver preserves Ledger firmware range checks", () => {
+  const semver = require("semver");
+
+  assert.equal(semver.satisfies("2.1.0", ">=2.0.0 <3.0.0"), true);
+  assert.equal(semver.satisfies("3.0.0", ">=2.0.0 <3.0.0"), false);
+  assert.equal(semver.valid("2.1.0"), "2.1.0");
+});
+
+test("compiled Ledger entrypoints remain importable", () => {
+  assert.doesNotThrow(() => require(path.join(projectRoot, "lib/provider/ledger/ledger.js")));
+  const transport = require("@ledgerhq/hw-transport");
+  assert.equal(typeof (transport.default || transport), "function");
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,12 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.11.2":
-  version "7.15.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
-  integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.19.4":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.10.tgz#a07b4d8fa27af131a633d7b3524db803eb4764c2"
+  integrity sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==
   dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.19.4":
-  version "7.20.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.6.tgz#facf4879bfed9b5326326273a64220f099b0fce3"
-  integrity sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==
-  dependencies:
-    regenerator-runtime "^0.13.11"
+    regenerator-runtime "^0.14.0"
 
 "@chain-registry/keplr@1.8.0":
   version "1.8.0"
@@ -3063,13 +3056,6 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
   integrity sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==
 
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
-
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
@@ -3615,15 +3601,10 @@ real-require@^0.1.0:
   resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.1.0.tgz#736ac214caa20632847b7ca8c1056a0767df9381"
   integrity sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==
 
-regenerator-runtime@^0.13.11:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
-
-regenerator-runtime@^0.13.4:
-  version "0.13.9"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
-  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -3730,17 +3711,10 @@ secure-random@1.1.2:
   resolved "https://registry.yarnpkg.com/secure-random/-/secure-random-1.1.2.tgz#ed103b460a851632d420d46448b2a900a41e7f7c"
   integrity sha512-H2bdSKERKdBV1SwoqYm6C0y+9EA94v6SUBOWO8kDndc4NoUih7Dv6Tsgma7zO1lv27wIvjlD0ZpMQk7um5dheQ==
 
-semver@7.8.5, semver@^7.5.3, semver@^7.7.3:
+semver@7.8.5, semver@^7.3.5, semver@^7.5.3, semver@^7.7.3:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
-
-semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  dependencies:
-    lru-cache "^6.0.0"
 
 semver@^7.3.8:
   version "7.6.2"
@@ -4188,11 +4162,6 @@ xstream@^11.14.0:
   dependencies:
     globalthis "^1.0.1"
     symbol-observable "^2.0.3"
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## What changed

- Coalesces both compatible Babel runtime selectors (`^7.11.2`, `^7.19.4`) at audited `@babel/runtime@7.26.10`.
- Advances the remaining vulnerable `semver@^7.3.5` path to the already-audited `7.8.5` artifact, while retaining the separate safe `7.6.2` path.
- Removes obsolete `regenerator-runtime@0.13`, `lru-cache@6`, and `yallist@4` artifacts that were reachable only from the superseded copies.
- Adds exact lock-target, Babel helper, SemVer range, and compiled Ledger import regressions.

Stacked on #634 and intentionally targets `security/wallet-compatible-leaves`.

## Supply-chain and compatibility audit

- Verified npm identity, source repository, integrity/shasum, license, engines, dependencies, signatures, deprecation state, and OSV results for the selected artifacts.
- All affected artifacts are signed, not deprecated, introduce no install hooks, and returned no OSV advisories.
- Exercised every Babel runtime helper imported by Ledger/chain-registry packages, including the regenerator entrypoint.
- All resulting versions satisfy every parent selector. `yarn check --verify-tree` passes.
- Independent fail-closed review repeated an empty-cache frozen install, full archived-checkout suite, packed consumer, registry/OSV checks, and found no blockers.

## Validation

Node `24.18.0`, Yarn `1.22.22`:

- scripts-disabled install + matching integrity — passed
- clean frozen lifecycle-enabled install + integrity — passed
- `yarn check --verify-tree` — passed
- `yarn lint` — passed
- `yarn test` — 95/95 passed
- `yarn build` — passed
- `npm pack --dry-run --json` — passed; 1,324 files
- lifecycle-enabled isolated packed consumer + package smoke — 6/6 passed
- compiled Ledger entrypoint and all imported Babel helpers — passed
- direct secp256k1 prebuild probe — loaded audited Linux x64 glibc prebuild
- `npm audit signatures` — 593 signatures, 42 attestations
- independent OSV queries — no advisories for affected versions
- `git diff --check` and credential-pattern scan — passed (`gitleaks` unavailable)

This stacked PR has no GitHub checks because CI only runs for PRs targeting `staging`; the equivalent and independent full validations ran locally.

## Residual risks

- The existing Keplr `starknet@^6` peer warning remains unchanged and is not hidden by this patch.
- Broad audit findings outside Babel runtime/SemVer remain separate work; this PR does not claim complete repository advisory closure.
- GitHub's live alert count remains default-branch-only until sequential stack merge.
