### PR TITLE
fix: patch protobuf UTF-8 leaf

### DIFF
--- a/tests/protobuf-utf8-leaf.test.cjs
+++ b/tests/protobuf-utf8-leaf.test.cjs
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global Buffer, __dirname, require */
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const projectRoot = path.resolve(__dirname, "..");
+const lockfile = fs.readFileSync(path.join(projectRoot, "yarn.lock"), "utf8");
+
+function lockedVersions(packageName) {
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const stanza = new RegExp(`^"${escaped}@[^\n]+:\\n(?:[ ]{2}[^\n]*\\n|[ ]{4}[^\n]*\\n)*`, "gm");
+  return [...lockfile.matchAll(stanza)]
+    .map((match) => match[0].match(/^[ ]{2}version "([^"]+)"$/m)?.[1])
+    .filter(Boolean)
+    .sort();
+}
+
+test("@protobufjs/utf8 has only the audited compatible lock target", () => {
+  assert.deepEqual(lockedVersions("@protobufjs/utf8"), ["1.1.1"]);
+});
+
+test("the patched UTF-8 helper preserves multibyte sizing and round trips", () => {
+  const utf8 = require("@protobufjs/utf8");
+  const value = "Carbon 🚀 交易";
+  const buffer = Buffer.alloc(utf8.length(value));
+  const written = utf8.write(value, buffer, 0);
+
+  assert.equal(written, Buffer.byteLength(value, "utf8"));
+  assert.equal(utf8.read(buffer, 0, written), value);
+  assert.equal(utf8.read(Uint8Array.from([0xc0, 0x80]), 0, 2), "\ufffd");
+});
+
+test("protobufjs uses the patched UTF-8 helper for message encoding", () => {
+  const protobuf = require("protobufjs");
+  const utf8 = require("@protobufjs/utf8");
+  const Message = new protobuf.Type("Message").add(new protobuf.Field("memo", 1, "string"));
+  const encoded = Message.encode({ memo: "Carbon 🚀" }).finish();
+
+  assert.equal(protobuf.util.utf8, utf8);
+  assert.equal(Message.decode(encoded).memo, "Carbon 🚀");
+});
+
+test("protobufjs major-version blockers remain explicit", () => {
+  const versions = [...lockfile.matchAll(/^protobufjs@[^\n]+:\n(?:[ ]{2}[^\n]*\n|[ ]{4}[^\n]*\n)*/gm)]
+    .map((match) => match[0].match(/^[ ]{2}version "([^"]+)"$/m)?.[1])
+    .filter(Boolean)
+    .sort();
+
+  assert.deepEqual(versions, ["6.11.2", "6.11.3", "6.11.4"]);
+  assert.equal(versions.some((version) => version.startsWith("7.")), false);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1145,9 +1145,9 @@
   integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
 
 "@protobufjs/utf8@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
-  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
+  integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.12"


### PR DESCRIPTION
## What changed

- Advances the single compatible `@protobufjs/utf8@^1.1.0` leaf from `1.1.0` to audited `1.1.1` without changing any Protobuf.js root.
- Adds exact lock-target, multibyte round-trip, malformed overlong UTF-8, and Protobuf.js integration regressions.
- Explicitly asserts that Protobuf.js `6.11.2`, `6.11.3`, and `6.11.4` remain; this patch does not misrepresent leaf remediation as full family closure.

Stacked on #635 and intentionally targets `security/ledger-runtime-leaves`.

## Supply-chain and compatibility audit

- All Protobuf.js parent selectors are `^1.1.0` and accept `1.1.1`.
- Verified canonical npm/source identity, BSD-3-Clause license, integrity, shasum, git commit, signature, absence of lifecycle scripts, and exact cached/installed artifact correspondence.
- The security regression proves `C0 80` now decodes as U+FFFD; independent review confirmed vulnerable `1.1.0` returned U+0000 for the same malformed bytes.
- Independent fail-closed review found no blockers after the test-hardening re-review.

## Validation

Node `24.18.0`, Yarn `1.22.22`:

- scripts-disabled install + matching integrity — passed
- clean frozen lifecycle-enabled install + integrity — passed
- `yarn check --verify-tree` — passed
- `yarn lint` — passed
- `yarn test` — 99/99 passed
- `yarn build` — passed
- `npm pack --dry-run --json` — passed; 1,324 files
- lifecycle-enabled isolated packed consumer + package smoke — 6/6 passed
- UTF-8 focused regressions — 4/4 passed
- direct secp256k1 prebuild probe — loaded audited Linux x64 glibc prebuild
- `npm audit signatures` — 593 signatures, 42 attestations
- `git diff --check` and credential-pattern scan — passed (`gitleaks` unavailable)

This stacked PR has no GitHub checks because CI only runs for PRs targeting `staging`; the equivalent and independent full validations ran locally.

## Residual blocker: Protobuf.js 6.x

This PR does **not** fix the Protobuf.js 6.x advisory family. Full closure requires Protobuf.js `7.6.3`, which is rejected by these owners:

- `@confio/ics23@0.6.8` → `protobufjs@^6.8.8`
- `secretjs@0.17.7` → exact `protobufjs@6.11.3`
- Keplr/Cosmos paths → `protobufjs@^6.11.2`
- the SDK currently declares exact `protobufjs@6.11.4`

A lock-only resolution would violate published root contracts and is intentionally not used. Those roots require focused major-migration PRs.
