### PR TITLE
chore: harden dependency maintenance policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "staging"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -12,11 +13,19 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 7
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 4
     groups:
-      routine-javascript-dependencies:
+      routine-runtime-dependencies:
         patterns:
           - "*"
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      routine-development-dependencies:
+        patterns:
+          - "*"
+        dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
@@ -29,6 +38,7 @@ updates:
       include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "staging"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -42,7 +52,6 @@ updates:
     open-pull-requests-limit: 2
     labels:
       - "dependencies"
-      - "javascript"
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/.github/workflows/node24.yml
+++ b/.github/workflows/node24.yml
@@ -36,11 +36,21 @@ jobs:
           corepack enable
           corepack prepare yarn@1.22.22 --activate
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile --non-interactive
+      - name: Resolve dependencies without lifecycle scripts
+        run: yarn install --frozen-lockfile --ignore-scripts --non-interactive
+
+      - name: Check script-disabled dependency integrity
+        run: yarn check --integrity --ignore-scripts
+
+      - name: Install dependencies with lifecycle scripts
+        run: |
+          rm -rf node_modules
+          yarn install --frozen-lockfile --non-interactive
 
       - name: Check dependency integrity
-        run: yarn check --integrity
+        run: |
+          yarn check --integrity
+          yarn check --verify-tree
 
       - name: Lint
         run: yarn lint
@@ -64,5 +74,8 @@ jobs:
           npm pack --pack-destination "$package_dir"
           cd "$consumer_dir"
           npm init --yes >/dev/null
-          npm install --ignore-scripts --no-audit --no-fund "$package_dir"/carbon-js-sdk-*.tgz
+          npm install --no-audit --no-fund "$package_dir"/carbon-js-sdk-*.tgz
           CARBON_SDK_PACKAGE=carbon-js-sdk node --test "$GITHUB_WORKSPACE/tests/package-smoke.test.cjs"
+          native_path=$(node -e 'const path=require("node:path"); const root=path.dirname(require.resolve("secp256k1/package.json")); process.stdout.write(require("node-gyp-build").path(root))')
+          test "${native_path#*/prebuilds/}" != "$native_path"
+          node -e 'require("secp256k1/bindings.js")'

--- a/DEPENDENCY_MAINTENANCE.md
+++ b/DEPENDENCY_MAINTENANCE.md
@@ -1,0 +1,70 @@
+# Dependency maintenance
+
+This repository treats dependency updates as supply-chain-sensitive changes. A green bot PR is compatibility evidence, not proof that a published artifact is safe.
+
+## Routine update policy
+
+Dependabot targets `staging` weekly and keeps major updates separate from grouped patch/minor work. Runtime and development updates are grouped independently so production graph changes are not hidden in tooling churn. GitHub Actions updates use the same cadence and retain immutable action commit SHAs after review.
+
+For every proposed package version:
+
+1. Verify the canonical registry identity, publisher/maintainer continuity, repository link, license, runtime engines, deprecation/yank state, publication history, and advisory status.
+2. Match the registry tarball integrity and shasum, inspect source/package changes, and review new lifecycle scripts, binaries, native code, network/shell behavior, and transitive dependencies.
+3. Confirm every parent selector accepts the selected version. Do not use blanket `resolutions` to force a patched leaf through an incompatible root contract.
+4. Install with lifecycle scripts disabled first, using matching Yarn integrity flags. Then repeat a clean frozen install with lifecycle scripts enabled.
+5. Run the validation below, inspect the lockfile graph diff, and document residual risks and blocked checks in the PR.
+
+Major ecosystem or runtime migrations must remain isolated from routine updates. A package without a compatible patched release remains visible until its owning root can be migrated safely.
+
+## Dependency contract checks
+
+SDK source imports must be declared directly, and direct roots that are no longer used must be removed rather than retained as accidental transitive providers.
+
+```bash
+yarn test:dependency-hygiene
+```
+
+This standalone command compiles the tracked source, then runs the existing source-import contract, dependency-contract, and unused-root/pruning regressions. The full `yarn test` suite also discovers these files, so the Node 24 workflow enforces the same gate without running a duplicate compilation.
+
+Do not add a heavy dependency analyzer merely to duplicate these tracked-source, compiled-artifact, and AST-based checks. Update the existing tests when the production import contract changes deliberately.
+
+## Required validation
+
+Use Node.js from `.nvmrc` and Yarn Classic `1.22.22`:
+
+```bash
+yarn install --frozen-lockfile --ignore-scripts --non-interactive
+yarn check --integrity --ignore-scripts
+rm -rf node_modules
+yarn install --frozen-lockfile --non-interactive
+yarn check --integrity
+yarn check --verify-tree
+yarn lint
+yarn test
+yarn test:dependency-hygiene
+yarn build
+npm pack --dry-run --json
+npm audit signatures
+git diff --check
+```
+
+For runtime graph changes, install the packed tarball in an isolated consumer **with lifecycle scripts enabled**, run `tests/package-smoke.test.cjs` against that package, and directly require native bindings. `secp256k1` must resolve an audited artifact under `prebuilds/`; its JavaScript fallback is not sufficient proof that the native backend loaded.
+
+Network, registry, authentication, or tooling failures are blocked checks, not incompatibility evidence and not passes.
+
+## Known major/unpatched boundaries
+
+The following families cannot be closed safely by lockfile overrides:
+
+- `elliptic@6.6.1` has no patched release for GHSA-848j-6mx2-7j84. Closure requires root migrations such as CosmJS `>=0.34`, Ethers 6, and modern BIP32/Ethereum utility paths.
+- `ws@7.4.6` is exact-pinned by `@ethersproject/providers@5.7.2`; full closure requires an Ethers/provider migration.
+- Axios `0.21.1` under SecretJS and Axios `0.27.2` under Keplr remain constrained by legacy roots.
+- Protobuf.js 6.x remains constrained by `@confio/ics23`, SecretJS, Keplr/Cosmos paths, and the SDK's current major contract. Full remediation requires an audited Protobuf.js 7 migration and root upgrades.
+
+The current detailed ownership paths, validated patch stack, and alert projection live under `plans/audits/`.
+
+## Review and merge discipline
+
+Dependency PRs remain drafts until their artifact audit and Node 24 validation are reviewed. Stacked PRs must be merged sequentially: squash the lowest layer, rebase only the next layer's delta onto updated `staging`, push with an explicit force-with-lease, retarget it, and wait for fresh CI before squashing. Never merge stacked branches independently or carry already-squashed commits forward.
+
+Repository settings and branch-protection changes are separate administrative actions and are not changed by this policy.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "sync-register": "bash scripts/sync-reset.sh && bash scripts/generate-registry.sh",
     "sync-reset": "bash scripts/sync-reset.sh",
     "test": "tsc && tsc-alias && node --test tests/*.test.cjs",
+    "test:dependency-hygiene": "tsc && tsc-alias && node --test tests/dependency-contracts.test.cjs tests/dependency-pruning.test.cjs tests/direct-import-contracts.test.cjs",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint .",
     "prepare": "rm -rf ./lib && eslint . && tsc && tsc-alias",


### PR DESCRIPTION
## What changed

- Makes Dependabot's `staging` target explicit, keeps majors separate, and splits grouped patch/minor updates into runtime and development review units. The npm PR limit rises to four so those two groups and independent majors are not needlessly starved.
- Removes the misleading `javascript` label from GitHub Actions updates while retaining dependency labeling and the existing weekly/cooldown cadence.
- Adds a standalone `yarn test:dependency-hygiene` command over the repository's existing source-import, direct-contract, and unused-root/compiled-artifact guards; no new analyzer dependency is introduced.
- Hardens Node 24 CI with a first frozen scripts-disabled install and matching integrity check, then a clean lifecycle-enabled install, `yarn check --verify-tree`, lifecycle-enabled packed-consumer installation, and direct native secp256k1 prebuild verification.
- Documents the fail-closed maintenance workflow, validation commands, lockfile/major-migration boundaries, and safe stacked-PR merge procedure in `DEPENDENCY_MAINTENANCE.md`.

Stacked on #638 and intentionally targets `security/residual-compatible-leaves`.

## Why

The previous workflow tested normal installs but did not expose lifecycle-script posture before execution, did not verify the resolved tree separately, and installed the packed consumer with scripts disabled—allowing a native-addon failure to be hidden by a JavaScript fallback. Dependabot also grouped runtime and development churn together. This policy makes those risks visible without adding a matrix, heavy dependency, new runner, or remote settings change.

## Security and workflow review

- Existing immutable action SHAs, `persist-credentials: false`, read-only permissions, public `ubuntu-latest`, Yarn caching, concurrency cancellation, and 20-minute timeout remain unchanged.
- No GitHub settings or branch protection were changed remotely.
- YAML parsing passed. `actionlint` was unavailable locally; two independent reviews inspected the workflow and Dependabot structure and found no blockers.
- The first independent review found the named hygiene script required pre-existing `lib`; the script now compiles first, was tested from a deleted `lib/`, and the duplicate CI invocation was removed because `yarn test` already discovers the same files.

## Validation

Node `24.18.0`, Yarn `1.22.22`:

- Dependabot/workflow YAML parse — passed
- actionlint — blocked: binary unavailable
- clean frozen scripts-disabled install + matching integrity — passed
- clean frozen lifecycle-enabled install + integrity + verify-tree — passed
- `yarn lint` — passed
- `yarn test` — 103/103 passed after restacking
- standalone `yarn test:dependency-hygiene` from absent `lib/` — 40/40 passed
- `yarn build` — passed
- `npm pack --dry-run --json` — passed; 1,324 files
- lifecycle-enabled isolated packed consumer + package smoke — 6/6 passed
- packed-consumer secp256k1 prebuild probe — loaded Linux x64 glibc prebuild; direct binding import passed
- `npm audit signatures` — 593 signatures, 42 attestations
- `git diff --check` and credential-pattern scan — passed (`gitleaks` unavailable)
- independent re-review — no findings

This stacked PR has no GitHub checks because CI only runs for PRs targeting `staging`; the equivalent local workflow validation passed. Fresh free CI should run after this layer is rebased/retargeted onto `staging` in sequence.

## Residual risks

- Dependabot schema is accepted syntactically and uses documented fields, but only GitHub can execute its service-side parser after merge.
- Existing major/unpatched advisory families remain documented rather than hidden through resolutions.
