### PR TITLE
fix: patch remaining compatible crypto leaves

### DIFF
--- a/tests/residual-compatible-leaves.test.cjs
+++ b/tests/residual-compatible-leaves.test.cjs
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global Buffer, __dirname, require */
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const projectRoot = path.resolve(__dirname, "..");
+const lockfile = fs.readFileSync(path.join(projectRoot, "yarn.lock"), "utf8");
+
+function lockedVersions(packageName) {
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const stanza = new RegExp(`^${escaped}@[^\n]+:\\n(?:[ ]{2}[^\n]*\\n|[ ]{4}[^\n]*\\n)*`, "gm");
+  return [...lockfile.matchAll(stanza)]
+    .map((match) => match[0].match(/^[ ]{2}version "([^"]+)"$/m)?.[1])
+    .filter(Boolean)
+    .sort();
+}
+
+test("compatible elliptic ranges resolve to 6.6.1 while the exact Ethers blocker stays visible", () => {
+  assert.deepEqual(lockedVersions("elliptic"), ["6.5.4", "6.6.1"]);
+  assert.match(lockfile, /^elliptic@6\.5\.4:\n[ ]{2}version "6\.5\.4"$/m);
+  assert.doesNotMatch(lockfile, /^elliptic@6\.5\.4,[^\n]*:/m);
+  assert.match(lockfile, /^elliptic@\^6\.4\.0,[^\n]*:\n[ ]{2}version "6\.6\.1"$/m);
+});
+
+test("compatible ws ranges resolve to 7.5.11 while the exact Ethers blocker stays visible", () => {
+  assert.deepEqual(lockedVersions("ws"), ["7.4.6", "7.5.11"]);
+  assert.match(lockfile, /^ws@7\.4\.6:\n[ ]{2}version "7\.4\.6"$/m);
+  assert.match(lockfile, /^ws@\^7, ws@\^7\.5\.11:\n[ ]{2}version "7\.5\.11"$/m);
+});
+
+test("elliptic 6.6.1 preserves deterministic secp256k1 signing", () => {
+  const EC = require("elliptic").ec;
+  const ec = new EC("secp256k1");
+  const key = ec.keyFromPrivate("1".padStart(64, "0"), "hex");
+  const digest = "4f3c2f8cf697e50e2465a586afb83f3da2f4723a55d67f0f97d0500fc482827c";
+  const signature = key.sign(digest, { canonical: true });
+
+  assert.equal(require("elliptic/package.json").version, "6.6.1");
+  assert.equal(ec.verify(digest, signature, key.getPublic()), true);
+  assert.equal(signature.r.toString(16), "6a5ac630a8403057f635795e5519dfafe00246f77dfaa99c2518a899dc57399a");
+  assert.equal(signature.s.toString(16), "6e430014324f78ae52786b280e40ebbdba8fcff5ad8cb6f9ee3c2cc6b5b0263f");
+});
+
+test("ws 7.5.11 preserves fragmented wallet transport messages", async () => {
+  const WebSocket = require("ws");
+  const server = new WebSocket.Server({ port: 0 });
+  await new Promise((resolve) => server.once("listening", resolve));
+  const address = server.address();
+  assert.equal(typeof address, "object");
+
+  const receivedByServer = new Promise((resolve, reject) => {
+    server.once("connection", (socket) => {
+      socket.once("error", reject);
+      socket.once("message", (data) => {
+        resolve(Buffer.from(data).toString("utf8"));
+        socket.send("ack");
+      });
+    });
+  });
+
+  const client = new WebSocket(`ws://127.0.0.1:${address.port}`);
+  await new Promise((resolve, reject) => {
+    client.once("open", resolve);
+    client.once("error", reject);
+  });
+  client.send("Car", { fin: false });
+  client.send("bon", { fin: false });
+  client.send(" SDK", { fin: true });
+  const reply = await new Promise((resolve, reject) => {
+    client.once("message", (data) => resolve(Buffer.from(data).toString("utf8")));
+    client.once("error", reject);
+  });
+
+  assert.equal(await receivedByServer, "Carbon SDK");
+  assert.equal(reply, "ack");
+  client.close();
+  await new Promise((resolve) => server.close(resolve));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2086,7 +2086,7 @@ duplexify@^4.1.2:
     readable-stream "^3.1.1"
     stream-shift "^1.0.2"
 
-elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3:
+elliptic@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -2099,7 +2099,7 @@ elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-elliptic@^6.5.4, elliptic@^6.5.7:
+elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3, elliptic@^6.5.4, elliptic@^6.5.7:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
   integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
@@ -4145,12 +4145,12 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@7.4.6, ws@^7:
+ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
-ws@^7.5.11:
+ws@^7, ws@^7.5.11:
   version "7.5.11"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.11.tgz#9460daf1812bb81a423c5b9eac746941a86310fa"
   integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==


### PR DESCRIPTION
## What changed

- Coalesces every compatible Elliptic selector (`^6.4.0`, `^6.5.2`, `^6.5.3`, `^6.5.4`, `^6.5.7`) onto the already-present audited `elliptic@6.6.1` artifact.
- Coalesces every compatible `ws@^7` selector onto the already-present audited `ws@7.5.11` artifact.
- Keeps the two exact Ethers 5 blockers literal and visible: `@ethersproject/signing-key` still owns exact `elliptic@6.5.4`, and `@ethersproject/providers` still owns exact `ws@7.4.6`.
- Adds lock-split, deterministic secp256k1 signing, and fragmented WebSocket regressions.

Stacked on #636 and intentionally targets `security/protobuf-utf8-leaf`. PR #637 will be restacked above this security layer.

## Supply-chain and compatibility audit

- No new artifact is introduced. Both selected tarballs, hashes, integrities, licenses, source repositories, and signatures were already audited and present in the parent lockfile.
- The diff changes selectors only: 564 lock artifacts before and after; no dependency bodies changed.
- Every moved selector accepts the target under SemVer. Exact Ethers selectors are split rather than overridden.
- Independent fail-closed review confirmed selector ownership, hashes, installed paths, and test coverage; no blockers.

## Validation

Node `24.18.0`, Yarn `1.22.22`:

- frozen scripts-disabled install + matching integrity — passed
- clean frozen lifecycle-enabled install + integrity + verify-tree — passed
- `yarn lint` — passed
- `yarn test` — 103/103 passed
- `yarn build` — passed
- focused Elliptic/ws regressions — 4/4 passed
- `npm pack --dry-run --json` — passed; 1,324 files
- lifecycle-enabled isolated packed consumer + package smoke — 6/6 passed
- packed-consumer secp256k1 prebuild probe — loaded audited Linux x64 glibc prebuild
- `npm audit signatures` — 590 installed packages verified; 42 attestations
- `git diff --check` and credential-pattern scan — passed (`gitleaks` unavailable)
- independent review — no findings

This stacked PR has no GitHub checks because CI only runs for PRs targeting `staging`; equivalent full local validation passed.

## Residual risks — no family closure claim

- `elliptic@6.6.1` remains affected by unpatched GHSA-848j-6mx2-7j84. This PR only removes avoidable older range-selected copies.
- Exact `elliptic@6.5.4` and `ws@7.4.6` under Ethers 5 cannot move through lockfile selection. Full closure requires a focused Ethers 6/provider migration.
- Other Elliptic consumers should migrate away from the family (CosmJS `>=0.34`, modern BIP32/Ethereum utilities) because 6.6.1 has no patched successor.
