### PR TITLE
ci: upgrade checkout action to v7

### DIFF
--- a/.github/workflows/node24.yml
+++ b/.github/workflows/node24.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## What changed

- Updates `actions/checkout` from the immutable v4 commit `34e114876b0b11c390a56381ad16ebd13914f8d5` to the official v7 release commit `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` so the checkout step uses GitHub Actions' Node 24 runtime instead of triggering the deprecated Node 20 action-runtime annotation.
- Retains `persist-credentials: false`, top-level read-only `contents` permission, the existing workflow triggers, concurrency guard, and timeout.

## Supply-chain review

- Canonical source: `actions/checkout`.
- Target: [`v7.0.0`](https://github.com/actions/checkout/releases/tag/v7.0.0), published 2026-06-18.
- The `v7` tag resolves to the exact pinned commit above.
- GitHub reports the target commit signature as verified.
- Target `action.yml` declares `using: node24` with bundled `dist/index.js` main/post entrypoints.
- No floating tag is used by this repository.

## Validation

- [x] Workflow YAML parses successfully.
- [x] Exact immutable SHA and `# v7` annotation verified.
- [x] Read-only permission and `persist-credentials: false` verified.
- [x] Base-relative diff is exactly one workflow line.
- [x] `git diff --check` passes.
- [x] Fresh GitHub CI executed the upgraded checkout action and completed the full Node 24 install, integrity, lint, test, build, package, consumer, and native-binding workflow in 3m01s.
- [x] Run annotations no longer identify `actions/checkout`; the remaining annotation names only the unchanged `actions/setup-node@v4` addressed separately by #641.

## Scope and risk

Workflow-only major action upgrade. The upstream bundled action implementation changed substantially across v4→v7; fresh CI is therefore a mandatory compatibility gate. No package, lockfile, source, test, or GitHub setting changes.
