### PR TITLE
ci: upgrade setup-node action to v7

### DIFF
--- a/.github/workflows/node24.yml
+++ b/.github/workflows/node24.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .nvmrc
           cache: yarn


### PR DESCRIPTION
## What changed

- Updates `actions/setup-node` from the immutable v4 commit `49933ea5288caeca8642d1e84afbd3f7d6820020` to the official v7 release commit `820762786026740c76f36085b0efc47a31fe5020` so Node setup and Yarn caching use GitHub Actions' Node 24 runtime instead of triggering the deprecated Node 20 action-runtime annotation.
- Retains `.nvmrc` selection, Yarn caching, top-level read-only `contents` permission, existing workflow triggers, concurrency guard, and timeout.

## Supply-chain review

- Canonical source: `actions/setup-node`.
- Target: [`v7.0.0`](https://github.com/actions/setup-node/releases/tag/v7.0.0), published 2026-07-14.
- The `v7` tag resolves to the exact pinned commit above.
- GitHub reports the target commit signature as verified.
- Target `action.yml` declares `using: node24` with bundled setup and cache-save entrypoints.
- No floating tag is used by this repository.

## Validation

- [x] Workflow YAML parses successfully.
- [x] Exact immutable SHA and `# v7` annotation verified.
- [x] `.nvmrc`, Yarn cache configuration, and read-only permission verified.
- [x] Base-relative diff is exactly one workflow line.
- [x] `git diff --check` passes.
- [x] Fresh GitHub CI executed the upgraded setup action and completed the full Node 24 install, integrity, lint, test, build, package, consumer, and native-binding workflow in 2m54s.
- [x] Run annotations no longer identify `actions/setup-node`; the remaining annotation names only the unchanged `actions/checkout@v4` addressed separately by #640.

## Scope and risk

Workflow-only major action upgrade. The upstream bundled action implementation changed substantially across v4→v7; fresh CI is therefore a mandatory compatibility gate. No package, lockfile, source, test, or GitHub setting changes.
