### PR TITLE
fix: follow Keplr registry main branch

### DIFF
--- a/src/modules/ibc.ts
+++ b/src/modules/ibc.ts
@@ -164,7 +164,7 @@ export class IBCModule extends BaseModule {
 
   async getChainInfo(chainName: string): Promise<ChainInfo | undefined> {
     if (!chainName || chainName === "mainnet") return undefined
-    const chainInfoResponse = await fetch(`https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/master/cosmos/${chainName}.json`)
+    const chainInfoResponse = await fetch(`https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/cosmos/${chainName}.json`)
     if (!chainInfoResponse.ok) {
       if (chainInfoResponse.status === 404) {
         return undefined;

--- a/src/provider/keplr/KeplrAccount.ts
+++ b/src/provider/keplr/KeplrAccount.ts
@@ -199,7 +199,7 @@ class KeplrAccount {
     const isMainnet = config.network === Network.MainNet;
 
     const chainId = config.chainId;
-    const url = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/master/cosmos/carbon.json"
+    const url = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/cosmos/carbon.json"
     let keplrChainInfo
     try {
       keplrChainInfo = await (await FetchUtils.fetch(url)).json();

--- a/tests/keplr-registry-branch.test.cjs
+++ b/tests/keplr-registry-branch.test.cjs
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global __dirname, require */
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const projectRoot = path.resolve(__dirname, "..");
+const keplrRegistryPrefix =
+  "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/";
+
+const registryConsumers = [
+  "src/modules/ibc.ts",
+  "src/provider/keplr/KeplrAccount.ts",
+  "lib/modules/ibc.js",
+  "lib/provider/keplr/KeplrAccount.js",
+];
+
+test("Keplr chain-registry consumers use the upstream main branch", () => {
+  for (const relativePath of registryConsumers) {
+    const content = fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
+    assert.ok(
+      content.includes(`${keplrRegistryPrefix}main/`),
+      `${relativePath} must fetch Keplr registry data from main`,
+    );
+    assert.ok(
+      !content.includes(`${keplrRegistryPrefix}master/`),
+      `${relativePath} must not fetch Keplr registry data from master`,
+    );
+  }
+});


### PR DESCRIPTION
## What changed

- Changes both runtime fetches for `chainapsis/keplr-chain-registry` from `master` to its new default branch, `main`, so dynamic IBC chain lookups and Carbon Keplr configuration do not depend on a legacy branch alias that upstream may remove.
- Adds a regression covering both source files and their compiled package output, preventing either consumer from returning to the stale Keplr `master` URL.

## Root cause and scope

`chainapsis/keplr-chain-registry` now reports `main` as its default branch. Its old raw `master` URLs currently still return content because GitHub redirects the legacy branch reference to the same commit, so this is a proactive reliability fix rather than an active outage.

The separate `cosmos/chain-registry` repository still defaults to `master`; its equivalent `main` raw URL returns 404. Those URLs are intentionally unchanged.

## Validation

- [x] RED: focused regression failed because `src/modules/ibc.ts` still used the Keplr `master` URL.
- [x] GREEN: focused source/compiled regression passed after the two URL changes.
- [x] Upstream default branch verified as `main` through the GitHub API.
- [x] Live `main/cosmos/carbon.json` returned HTTP 200 and valid Carbon chain metadata.
- [x] Lifecycle-enabled frozen install and Yarn integrity passed on Node 24.18.0.
- [x] Lint and TypeScript build passed.
- [x] Full test suite: 104/104 passed.
- [x] Dependency-hygiene suite: 40/40 passed.
- [x] Package dry-run and `git diff --check` passed.
- [x] Fresh GitHub CI passed in 2m57s.

## Risk

Low and focused: two runtime URL branch segments plus one structural regression test. No package, lockfile, workflow, public API, or GitHub setting changes.
