### PR TITLE
fix: preserve Leap uint64 account numbers

### DIFF
--- a/src/provider/leap/LeapAccount.ts
+++ b/src/provider/leap/LeapAccount.ts
@@ -39,7 +39,7 @@ class LeapAccount {
           bodyBytes,
           authInfoBytes,
           chainId,
-          accountNumber: new Long(Number(accountNumber)),
+          accountNumber: Long.fromString(accountNumber.toString(), true),
         }
         return await leap!.signDirect(chainId, signerAddress, parsedDoc, signOpts);
       })

--- a/tests/leap-account-number.test.cjs
+++ b/tests/leap-account-number.test.cjs
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global __dirname, require */
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+const Long = require("long");
+
+const projectRoot = path.resolve(__dirname, "..");
+
+test("Leap direct signing preserves uint64 account numbers above 32 bits", async () => {
+  const { LeapAccount } = require(path.join(projectRoot, "lib/index.js"));
+  let forwarded;
+  const leap = {
+    async signDirect(_chainId, _address, doc) {
+      forwarded = doc.accountNumber;
+      return {
+        signed: doc,
+        signature: {
+          pub_key: { type: "tendermint/PubKeySecp256k1", value: "AQ==" },
+          signature: "AQ==",
+        },
+      };
+    },
+  };
+  const signer = LeapAccount.createLeapSigner(leap, "carbon-1");
+  const accountNumber = (1n << 40n) + 123n;
+
+  await signer.signDirect("swth1contract", {
+    bodyBytes: new Uint8Array(),
+    authInfoBytes: new Uint8Array(),
+    chainId: "carbon-1",
+    accountNumber,
+  });
+
+  assert.equal(Long.isLong(forwarded), true);
+  assert.equal(forwarded.unsigned, true);
+  assert.equal(forwarded.toString(), accountNumber.toString());
+});


### PR DESCRIPTION
## What changed

- Preserves Cosmos `uint64` account numbers when Carbon converts CosmJS `bigint` signing documents to Leap's `Long`-based signing interface.
- Replaces `new Long(Number(accountNumber))` with `Long.fromString(accountNumber.toString(), true)`.
- Adds a regression for `2^40 + 123`, proving the exact unsigned value reaches Leap.

## Why

`Number` plus the two-argument `Long` constructor truncated values above 32 bits. This bug was exposed during compatibility review and is independent of dependency versions, so it is isolated in its own PR.

## TDD evidence

- RED: old implementation forwarded a signed/truncated Long.
- GREEN: exact unsigned conversion preserves the full uint64 value.

## Stack

1. #643 — compatibility baseline
2. **This PR**
3. #644 — Cosmos Kit/Leap migration
4. #646 — final audit/report

## Validation

- [x] Node 24.18.0
- [x] focused uint64 regression passed
- [x] full suite: 109/109 passed on this layer
- [x] dependency hygiene: 40/40 passed
- [x] build and `git diff --check`
- [ ] GitHub CI after #643 merge/restack

No dependency or lockfile changes are included.