### PR TITLE
fix: handle retired IBC chain metadata

### DIFF
--- a/src/constant/ibc.ts
+++ b/src/constant/ibc.ts
@@ -2160,6 +2160,14 @@ export interface ExtendedChainInfo extends ChainInfo {
   minimalDenomMap: MinimalDenomMap;
   bestRpcs: URLProviderObj[];
   activeRpc?: string;
+  /** Cosmos Chain Registry lifecycle status observed while loading this metadata. */
+  registryStatus?: string;
+  /**
+   * Derived transfer eligibility. This is separate from the canonical Carbon
+   * bridge.enabled value and is false when that bridge is disabled or the
+   * external chain registry explicitly reports the chain as killed.
+   */
+  isTransferAvailable: boolean;
 }
 
 export interface URLProviderObj {

--- a/src/constant/ibc.ts
+++ b/src/constant/ibc.ts
@@ -2165,9 +2165,10 @@ export interface ExtendedChainInfo extends ChainInfo {
   /**
    * Derived transfer eligibility. This is separate from the canonical Carbon
    * bridge.enabled value and is false when that bridge is disabled or the
-   * external chain registry explicitly reports the chain as killed.
+   * external chain registry explicitly reports the chain as killed. Always
+   * populated by IBCModule.getChainInfoMap; optional for source compatibility.
    */
-  isTransferAvailable: boolean;
+  isTransferAvailable?: boolean;
 }
 
 export interface URLProviderObj {

--- a/src/modules/ibc.ts
+++ b/src/modules/ibc.ts
@@ -86,6 +86,9 @@ export class IBCModule extends BaseModule {
 
     const ibcBridges = tokenClient.bridges.ibc;
     const chainsResponse = await fetch(`https://chains.cosmos.directory/`);
+    if (!chainsResponse.ok) {
+      throw new Error(`Failed to fetch Cosmos Directory chains: HTTP ${chainsResponse.status}`);
+    }
     const chainsData = (await chainsResponse.json() as CosmosChainsObj);
     const chainInfoMap: TypeUtils.SimpleMap<ExtendedChainInfo> = {};
 
@@ -95,9 +98,20 @@ export class IBCModule extends BaseModule {
       const chainId = ibcBridge.chain_id_name;
       const chainName = ibcBridge.chain_id_name.match(ibcNetworkRegex)?.[1] ?? "";
       const chainData = chainsData.chains.find((d) => d.chain_id === chainId);
-      let chainInfo: ChainInfo | undefined = await this.getChainInfo(chainName);
+      const registryStatus = chainData?.status ?? await this.getChainRegistryStatus(chainName);
+      const isRegistryKilled = registryStatus === "killed";
+      let chainInfo: ChainInfo | undefined;
+
+      if (isRegistryKilled) {
+        // Keep enough metadata for callers that still reference the canonical
+        // on-chain bridge, but do not probe removed registry files or present
+        // embedded metadata as evidence that transfers remain available.
+        chainInfo = IBCUtils.EmbedChainInfos[chainId];
+      } else {
+        chainInfo = await this.getChainInfo(chainName);
+      }
       
-      if (chainInfo === undefined) {
+      if (chainInfo === undefined && !isRegistryKilled) {
         const fallbackChainInfo = await this.getAssembledChainInfo(chainId, chainData);
         chainInfo = fallbackChainInfo;
       }
@@ -106,17 +120,22 @@ export class IBCModule extends BaseModule {
         chainInfoMap[ibcBridge.chain_id_name] = {
           ...chainInfo,
           minimalDenomMap: {},
-          bestRpcs: chainData?.best_apis.rpc ?? [],
+          bestRpcs: isRegistryKilled ? [] : chainData?.best_apis?.rpc ?? [],
+          registryStatus,
+          isTransferAvailable: ibcBridge.enabled && !isRegistryKilled,
         };
       }
     }
 
     const carbonChainInfo = await KeplrAccount.getChainInfo(this.sdkProvider);
     if (carbonChainInfo) {
+      const registryStatus = chainsData.chains.find((d) => d.chain_id === carbonChainInfo.chainId)?.status;
       chainInfoMap[carbonChainInfo.chainId] = {
         ...carbonChainInfo,
         minimalDenomMap: {},
         bestRpcs: [],
+        registryStatus,
+        isTransferAvailable: registryStatus !== "killed",
       };
     }
 
@@ -169,18 +188,41 @@ export class IBCModule extends BaseModule {
       if (chainInfoResponse.status === 404) {
         return undefined;
       }
+      throw new Error(`Failed to fetch Keplr chain info for ${chainName}: HTTP ${chainInfoResponse.status}`);
     }
     const chainInfoJson = await chainInfoResponse.json();
     return chainInfoJson as ChainInfo;
+  }
+
+  async getChainRegistryStatus(chainName: string): Promise<string | undefined> {
+    if (!chainName) return undefined;
+    const url = `https://raw.githubusercontent.com/cosmos/chain-registry/master/${chainName}/chain.json`;
+    const chainInfoResponse = await fetch(url);
+    if (!chainInfoResponse.ok) {
+      if (chainInfoResponse.status === 404) {
+        return undefined;
+      }
+      throw new Error(`Failed to fetch Cosmos Chain Registry status for ${chainName}: HTTP ${chainInfoResponse.status}`);
+    }
+    const chainInfoJson = await chainInfoResponse.json() as { status?: string };
+    return chainInfoJson.status;
   }
 
   async getAssembledChainInfo(chainId: string, chainData?: ChainRegistryItem): Promise<ChainInfo | undefined> {
     const defaultChainInfo = IBCUtils.EmbedChainInfos[chainId];
     if (chainData) {
       try {
-        const chainInfoResponse = await fetch(`https://raw.githubusercontent.com/cosmos/chain-registry/master/${chainData.chain_name}/chain.json`);
+        const chainInfoUrl = `https://raw.githubusercontent.com/cosmos/chain-registry/master/${chainData.chain_name}/chain.json`;
+        const chainInfoResponse = await fetch(chainInfoUrl);
+        if (!chainInfoResponse.ok) {
+          throw new Error(`Failed to fetch Cosmos Chain Registry chain info for ${chainId}: HTTP ${chainInfoResponse.status}`);
+        }
         const chainInfoJson = await chainInfoResponse.json();
-        const chainAssetListResponse = await fetch(`https://raw.githubusercontent.com/cosmos/chain-registry/master/${chainData.chain_name}/assetlist.json`);
+        const chainAssetListUrl = `https://raw.githubusercontent.com/cosmos/chain-registry/master/${chainData.chain_name}/assetlist.json`;
+        const chainAssetListResponse = await fetch(chainAssetListUrl);
+        if (!chainAssetListResponse.ok) {
+          throw new Error(`Failed to fetch Cosmos Chain Registry assets for ${chainId}: HTTP ${chainAssetListResponse.status}`);
+        }
         const assetListJson = await chainAssetListResponse.json();
         const features: string[] = [];
         if (chainData.cosmwasm_enabled) {
@@ -248,8 +290,8 @@ export class IBCModule extends BaseModule {
         });
 
         return {
-          rpc: defaultChainInfo.rpc ?? chainInfoJson.apis.rpc[0].address,
-          rest: defaultChainInfo.rest ?? chainInfoJson.apis.rest[0].address,
+          rpc: defaultChainInfo?.rpc ?? chainInfoJson.apis.rpc[0].address,
+          rest: defaultChainInfo?.rest ?? chainInfoJson.apis.rest[0].address,
           chainId: chainInfoJson.chain_id,
           chainName: chainInfoJson.chain_name,
           bip44:

--- a/src/modules/ibc.ts
+++ b/src/modules/ibc.ts
@@ -9,6 +9,18 @@ import BigNumber from "bignumber.js";
 import Long from "long";
 import BaseModule from "./base";
 
+interface ChainRegistryChainInfo {
+  status?: string;
+  chain_id?: string;
+  chain_name?: string;
+  pretty_name?: string;
+  bech32_prefix?: string;
+  slip44?: number;
+  staking?: {
+    staking_tokens?: Array<{ denom: string }>;
+  };
+}
+
 export class IBCModule extends BaseModule {
   /** @deprecated please use sendIbcTransferUpdated instead */
   public async sendIBCTransfer(params: IBCModule.SendIBCTransferParams, msgOpts?: CarbonTx.SignTxOpts) {
@@ -98,7 +110,11 @@ export class IBCModule extends BaseModule {
       const chainId = ibcBridge.chain_id_name;
       const chainName = ibcBridge.chain_id_name.match(ibcNetworkRegex)?.[1] ?? "";
       const chainData = chainsData.chains.find((d) => d.chain_id === chainId);
-      const registryStatus = chainData?.status ?? await this.getChainRegistryStatus(chainName);
+      let registryChainInfo: ChainRegistryChainInfo | undefined;
+      if (chainData?.status === undefined) {
+        registryChainInfo = await this.getChainRegistryInfo(chainName);
+      }
+      const registryStatus = chainData?.status ?? registryChainInfo?.status;
       const isRegistryKilled = registryStatus === "killed";
       let chainInfo: ChainInfo | undefined;
 
@@ -106,7 +122,25 @@ export class IBCModule extends BaseModule {
         // Keep enough metadata for callers that still reference the canonical
         // on-chain bridge, but do not probe removed registry files or present
         // embedded metadata as evidence that transfers remain available.
-        chainInfo = IBCUtils.EmbedChainInfos[chainId];
+        const embeddedChainInfo = IBCUtils.EmbedChainInfos[chainId];
+        if (embeddedChainInfo) {
+          chainInfo = {
+            ...embeddedChainInfo,
+            rpc: "",
+            rest: "",
+            currencies: [...embeddedChainInfo.currencies],
+            feeCurrencies: [],
+            features: [],
+          };
+        } else {
+          registryChainInfo ??= await this.getChainRegistryInfo(chainName);
+          chainInfo = this.getRetiredChainInfo(
+            chainId,
+            ibcBridge.chainName,
+            chainData,
+            registryChainInfo,
+          );
+        }
       } else {
         chainInfo = await this.getChainInfo(chainName);
       }
@@ -195,6 +229,10 @@ export class IBCModule extends BaseModule {
   }
 
   async getChainRegistryStatus(chainName: string): Promise<string | undefined> {
+    return (await this.getChainRegistryInfo(chainName))?.status;
+  }
+
+  private async getChainRegistryInfo(chainName: string): Promise<ChainRegistryChainInfo | undefined> {
     if (!chainName) return undefined;
     const url = `https://raw.githubusercontent.com/cosmos/chain-registry/master/${chainName}/chain.json`;
     const chainInfoResponse = await fetch(url);
@@ -204,8 +242,46 @@ export class IBCModule extends BaseModule {
       }
       throw new Error(`Failed to fetch Cosmos Chain Registry status for ${chainName}: HTTP ${chainInfoResponse.status}`);
     }
-    const chainInfoJson = await chainInfoResponse.json() as { status?: string };
-    return chainInfoJson.status;
+    const chainInfoJson = await chainInfoResponse.json() as ChainRegistryChainInfo;
+    return chainInfoJson;
+  }
+
+  private getRetiredChainInfo(
+    chainId: string,
+    bridgeChainName: string,
+    chainData?: ChainRegistryItem,
+    registryChainInfo?: ChainRegistryChainInfo,
+  ): ChainInfo {
+    const coinMinimalDenom = chainData?.denom
+      ?? registryChainInfo?.staking?.staking_tokens?.[0]?.denom
+      ?? "";
+    const currency: Currency = {
+      coinDenom: chainData?.symbol ?? coinMinimalDenom.toUpperCase(),
+      coinMinimalDenom,
+      coinDecimals: chainData?.decimals ?? 0,
+    };
+    const bech32Prefix = chainData?.bech32_prefix ?? registryChainInfo?.bech32_prefix ?? "";
+
+    return {
+      // Deliberately omit stale endpoints and transfer features. The object is
+      // present only so existing map consumers can identify the retired bridge.
+      rpc: "",
+      rest: "",
+      chainId,
+      chainName: chainData?.pretty_name
+        ?? registryChainInfo?.pretty_name
+        ?? bridgeChainName
+        ?? registryChainInfo?.chain_name
+        ?? chainId,
+      bip44: {
+        coinType: registryChainInfo?.slip44 ?? 118,
+      },
+      bech32Config: IBCAddress.defaultBech32Config(bech32Prefix),
+      stakeCurrency: currency,
+      currencies: coinMinimalDenom ? [currency] : [],
+      feeCurrencies: [],
+      features: [],
+    };
   }
 
   async getAssembledChainInfo(chainId: string, chainData?: ChainRegistryItem): Promise<ChainInfo | undefined> {

--- a/src/provider/keplr/KeplrAccount.ts
+++ b/src/provider/keplr/KeplrAccount.ts
@@ -202,7 +202,11 @@ class KeplrAccount {
     const url = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/cosmos/carbon.json"
     let keplrChainInfo
     try {
-      keplrChainInfo = await (await FetchUtils.fetch(url)).json();
+      const response = await FetchUtils.fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Carbon chain info: HTTP ${response.status}`);
+      }
+      keplrChainInfo = await response.json();
     } catch (error) {
       console.warn(error)
     }

--- a/tests/ibc-chain-info-status.test.cjs
+++ b/tests/ibc-chain-info-status.test.cjs
@@ -158,6 +158,10 @@ test("a registry-killed chain skips Keplr while preserving the enabled on-chain 
     assert.equal(result["stargaze-1"].registryStatus, "killed");
     assert.equal(result["stargaze-1"].isTransferAvailable, false);
     assert.equal(result["stargaze-1"].chainId, "stargaze-1");
+    assert.equal(result["stargaze-1"].rpc, "");
+    assert.equal(result["stargaze-1"].rest, "");
+    assert.deepEqual(result["stargaze-1"].feeCurrencies, []);
+    assert.deepEqual(result["stargaze-1"].features, []);
   });
 });
 
@@ -179,6 +183,40 @@ test("a killed chain omitted by Cosmos Directory checks Chain Registry status be
     assert.equal(requestedUrls.includes(`${keplrPrefix}omniflixhub.json`), false);
     assert.equal(result["omniflixhub-1"].registryStatus, "killed");
     assert.equal(result["omniflixhub-1"].isTransferAvailable, false);
+  });
+});
+
+test("a killed chain without embedded metadata remains explicitly unavailable", { concurrency: false }, async (t) => {
+  const chainId = "retireddynamic-1";
+  const bridge = ibcBridge(chainId, true);
+  bridge.chainName = "Retired Dynamic";
+  const { provider, tokenClient } = sdkProvider([bridge]);
+  const module = new IBCModule(provider);
+  const responses = {
+    ...baseResponses([]),
+    [`${chainRegistryPrefix}retireddynamic/chain.json`]: jsonResponse({
+      chain_id: chainId,
+      chain_name: "retireddynamic",
+      pretty_name: "Retired Dynamic",
+      status: "killed",
+      slip44: 118,
+      bech32_prefix: "retired",
+      staking: { staking_tokens: [{ denom: "uretired" }] },
+    }),
+  };
+
+  await withFetch(t, responses, async (requestedUrls) => {
+    const result = await module.getChainInfoMap();
+
+    assert.equal(requestedUrls.includes(`${keplrPrefix}retireddynamic.json`), false);
+    assert.equal(tokenClient.bridges.ibc[0], bridge);
+    assert.equal(tokenClient.bridges.ibc[0].enabled, true);
+    assert.ok(result[chainId]);
+    assert.equal(result[chainId].chainId, chainId);
+    assert.equal(result[chainId].chainName, "Retired Dynamic");
+    assert.equal(result[chainId].registryStatus, "killed");
+    assert.equal(result[chainId].isTransferAvailable, false);
+    assert.deepEqual(result[chainId].bestRpcs, []);
   });
 });
 
@@ -241,6 +279,23 @@ test("a live chain missing from Keplr falls back to Cosmos Chain Registry", { co
   });
 });
 
+test("an explicit unknown registry status is not treated as killed", { concurrency: false }, async (t) => {
+  const { provider } = sdkProvider([ibcBridge("unknownstatus-1")]);
+  const module = new IBCModule(provider);
+  const responses = {
+    ...baseResponses([chainSummary("unknownstatus-1", "unknown", "unknownstatus")]),
+    [`${keplrPrefix}unknownstatus.json`]: jsonResponse(chainInfo("unknownstatus-1", "Unknown Status")),
+  };
+
+  await withFetch(t, responses, async (requestedUrls) => {
+    const result = await module.getChainInfoMap();
+
+    assert.equal(requestedUrls.includes(`${keplrPrefix}unknownstatus.json`), true);
+    assert.equal(result["unknownstatus-1"].registryStatus, "unknown");
+    assert.equal(result["unknownstatus-1"].isTransferAvailable, true);
+  });
+});
+
 test("missing registry status is not treated as killed", { concurrency: false }, async (t) => {
   const { provider } = sdkProvider([ibcBridge("unknown-1")]);
   const module = new IBCModule(provider);
@@ -256,5 +311,28 @@ test("missing registry status is not treated as killed", { concurrency: false },
     assert.equal(requestedUrls.includes(`${keplrPrefix}unknown.json`), true);
     assert.equal(result["unknown-1"].registryStatus, undefined);
     assert.equal(result["unknown-1"].isTransferAvailable, true);
+  });
+});
+
+test("the Carbon registry response is checked before parsing", { concurrency: false }, async (t) => {
+  const { provider } = sdkProvider([]);
+  const module = new IBCModule(provider);
+  let parsed = false;
+  const responses = {
+    [directoryUrl]: jsonResponse({ chains: [] }),
+    [`${keplrPrefix}carbon.json`]: {
+      ok: false,
+      status: 503,
+      async json() {
+        parsed = true;
+        return carbonChainInfo;
+      },
+    },
+  };
+
+  await withFetch(t, responses, async () => {
+    const result = await module.getChainInfoMap();
+    assert.equal(parsed, false);
+    assert.equal(result["carbon-1"].chainId, "carbon-1");
   });
 });

--- a/tests/ibc-chain-info-status.test.cjs
+++ b/tests/ibc-chain-info-status.test.cjs
@@ -1,0 +1,260 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global __dirname, require */
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const projectRoot = path.resolve(__dirname, "..");
+const { IBCModule } = require(path.join(projectRoot, "lib/index.js"));
+
+const directoryUrl = "https://chains.cosmos.directory/";
+const keplrPrefix = "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/cosmos/";
+const chainRegistryPrefix = "https://raw.githubusercontent.com/cosmos/chain-registry/master/";
+
+function jsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body;
+    },
+  };
+}
+
+function unparseableErrorResponse(status) {
+  return {
+    ok: false,
+    status,
+    async json() {
+      throw new Error(`HTTP ${status} response must not be parsed`);
+    },
+  };
+}
+
+function chainInfo(chainId, chainName = chainId) {
+  return {
+    rpc: `https://rpc.${chainId}`,
+    rest: `https://rest.${chainId}`,
+    chainId,
+    chainName,
+    bip44: { coinType: 118 },
+    bech32Config: {
+      bech32PrefixAccAddr: "cosmos",
+      bech32PrefixAccPub: "cosmospub",
+      bech32PrefixValAddr: "cosmosvaloper",
+      bech32PrefixValPub: "cosmosvaloperpub",
+      bech32PrefixConsAddr: "cosmosvalcons",
+      bech32PrefixConsPub: "cosmosvalconspub",
+    },
+    stakeCurrency: {
+      coinDenom: "ATOM",
+      coinMinimalDenom: "uatom",
+      coinDecimals: 6,
+    },
+    currencies: [],
+    feeCurrencies: [],
+    features: ["ibc-transfer"],
+  };
+}
+
+const carbonChainInfo = chainInfo("carbon-1", "Carbon");
+
+function chainSummary(chainId, status, chainName = chainId.replace(/-\d+$/, "")) {
+  return {
+    chain_id: chainId,
+    chain_name: chainName,
+    status,
+    best_apis: { rpc: [], rest: [] },
+  };
+}
+
+function ibcBridge(chainId, enabled = true) {
+  return {
+    name: `${chainId} via IBC`,
+    bridgeId: { toNumber: () => 2 },
+    chainId: { toNumber: () => 33 },
+    bridgeName: "IBC",
+    chainName: chainId,
+    enabled,
+    bridgeAddresses: [],
+    chain_id_name: chainId,
+    channels: {
+      src_channel: "channel-32",
+      dst_channel: "channel-279",
+      port_id: "transfer",
+    },
+  };
+}
+
+function sdkProvider(bridges) {
+  const tokenClient = {
+    bridges: { polynetwork: [], ibc: bridges, axelar: [] },
+    tokenForDenom() {
+      return undefined;
+    },
+    geckoTokenNames: {},
+  };
+  return {
+    tokenClient,
+    provider: {
+      getTokenClient() {
+        return tokenClient;
+      },
+      getConfig() {
+        return {
+          Bech32Prefix: "swth",
+          chainId: "carbon-1",
+          network: "mainnet",
+          restUrl: "https://api.carbon.network",
+          tmRpcUrl: "https://tm-api.carbon.network",
+        };
+      },
+      query: {
+        fee: {
+          async MinGasPriceAll() {
+            return { minGasPrices: [] };
+          },
+        },
+      },
+    },
+  };
+}
+
+async function withFetch(t, responses, run) {
+  const originalFetch = globalThis.fetch;
+  const requestedUrls = [];
+  globalThis.fetch = async (input) => {
+    const url = String(input);
+    requestedUrls.push(url);
+    const response = responses[url];
+    assert.ok(response, `unexpected fetch: ${url}`);
+    return typeof response === "function" ? response() : response;
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  return run(requestedUrls);
+}
+
+function baseResponses(chains) {
+  return {
+    [directoryUrl]: jsonResponse({ chains }),
+    [`${keplrPrefix}carbon.json`]: jsonResponse(carbonChainInfo),
+  };
+}
+
+test("a registry-killed chain skips Keplr while preserving the enabled on-chain bridge", { concurrency: false }, async (t) => {
+  const bridge = ibcBridge("stargaze-1", true);
+  const { provider, tokenClient } = sdkProvider([bridge]);
+  const module = new IBCModule(provider);
+
+  await withFetch(t, baseResponses([chainSummary("stargaze-1", "killed", "stargaze")]), async (requestedUrls) => {
+    const result = await module.getChainInfoMap();
+
+    assert.equal(requestedUrls.includes(`${keplrPrefix}stargaze.json`), false);
+    assert.equal(tokenClient.bridges.ibc.length, 1);
+    assert.equal(tokenClient.bridges.ibc[0], bridge);
+    assert.equal(tokenClient.bridges.ibc[0].enabled, true);
+    assert.equal(result["stargaze-1"].registryStatus, "killed");
+    assert.equal(result["stargaze-1"].isTransferAvailable, false);
+    assert.equal(result["stargaze-1"].chainId, "stargaze-1");
+  });
+});
+
+test("a killed chain omitted by Cosmos Directory checks Chain Registry status before Keplr", { concurrency: false }, async (t) => {
+  const { provider } = sdkProvider([ibcBridge("omniflixhub-1")]);
+  const module = new IBCModule(provider);
+  const responses = {
+    ...baseResponses([]),
+    [`${chainRegistryPrefix}omniflixhub/chain.json`]: jsonResponse({
+      chain_id: "omniflixhub-1",
+      chain_name: "omniflixhub",
+      status: "killed",
+    }),
+  };
+
+  await withFetch(t, responses, async (requestedUrls) => {
+    const result = await module.getChainInfoMap();
+
+    assert.equal(requestedUrls.includes(`${keplrPrefix}omniflixhub.json`), false);
+    assert.equal(result["omniflixhub-1"].registryStatus, "killed");
+    assert.equal(result["omniflixhub-1"].isTransferAvailable, false);
+  });
+});
+
+test("a live chain with Keplr metadata remains transferable", { concurrency: false }, async (t) => {
+  const { provider } = sdkProvider([ibcBridge("osmosis-1")]);
+  const module = new IBCModule(provider);
+  const responses = {
+    ...baseResponses([chainSummary("osmosis-1", "live", "osmosis")]),
+    [`${keplrPrefix}osmosis.json`]: jsonResponse(chainInfo("osmosis-1", "Osmosis")),
+  };
+
+  await withFetch(t, responses, async (requestedUrls) => {
+    const result = await module.getChainInfoMap();
+
+    assert.equal(requestedUrls.includes(`${keplrPrefix}osmosis.json`), true);
+    assert.equal(result["osmosis-1"].chainName, "Osmosis");
+    assert.equal(result["osmosis-1"].registryStatus, "live");
+    assert.equal(result["osmosis-1"].isTransferAvailable, true);
+  });
+});
+
+test("a live chain missing from Keplr falls back to Cosmos Chain Registry", { concurrency: false }, async (t) => {
+  const { provider } = sdkProvider([ibcBridge("fallback-1")]);
+  const module = new IBCModule(provider);
+  const registryChain = {
+    chain_id: "fallback-1",
+    chain_name: "fallback",
+    status: "live",
+    pretty_name: "Fallback Chain",
+    slip44: 118,
+    bech32_prefix: "fallback",
+    staking: { staking_tokens: [{ denom: "ufallback" }] },
+    fees: { fee_tokens: [{ denom: "ufallback", low_gas_price: 0.01, average_gas_price: 0.025, high_gas_price: 0.04 }] },
+    apis: {
+      rpc: [{ address: "https://rpc.fallback" }],
+      rest: [{ address: "https://rest.fallback" }],
+    },
+  };
+  const registryAssets = {
+    assets: [{
+      base: "ufallback",
+      denom_units: [{ denom: "ufallback", exponent: 0 }, { denom: "fallback", exponent: 6 }],
+      coingecko_id: "fallback",
+    }],
+  };
+  const responses = {
+    ...baseResponses([chainSummary("fallback-1", "live", "fallback")]),
+    [`${keplrPrefix}fallback.json`]: unparseableErrorResponse(404),
+    [`${chainRegistryPrefix}fallback/chain.json`]: jsonResponse(registryChain),
+    [`${chainRegistryPrefix}fallback/assetlist.json`]: jsonResponse(registryAssets),
+  };
+
+  await withFetch(t, responses, async () => {
+    const result = await module.getChainInfoMap();
+
+    assert.equal(result["fallback-1"].chainId, "fallback-1");
+    assert.equal(result["fallback-1"].stakeCurrency.coinMinimalDenom, "ufallback");
+    assert.equal(result["fallback-1"].registryStatus, "live");
+    assert.equal(result["fallback-1"].isTransferAvailable, true);
+  });
+});
+
+test("missing registry status is not treated as killed", { concurrency: false }, async (t) => {
+  const { provider } = sdkProvider([ibcBridge("unknown-1")]);
+  const module = new IBCModule(provider);
+  const responses = {
+    ...baseResponses([]),
+    [`${chainRegistryPrefix}unknown/chain.json`]: unparseableErrorResponse(404),
+    [`${keplrPrefix}unknown.json`]: jsonResponse(chainInfo("unknown-1", "Unknown but available")),
+  };
+
+  await withFetch(t, responses, async (requestedUrls) => {
+    const result = await module.getChainInfoMap();
+
+    assert.equal(requestedUrls.includes(`${keplrPrefix}unknown.json`), true);
+    assert.equal(result["unknown-1"].registryStatus, undefined);
+    assert.equal(result["unknown-1"].isTransferAvailable, true);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve Carbon's canonical per-chain IBC bridge records and `bridge.enabled` values while deriving registry-based transfer availability separately
- inspect Cosmos Chain Registry status before Keplr, including a direct Chain Registry status lookup when Cosmos Directory omits killed chains
- keep retired-chain entries so existing callers do not dereference a missing map entry, including chains without embedded metadata, while marking them with `registryStatus: "killed"` and `isTransferAvailable: false`
- strip RPC, REST, fee, and transfer-feature metadata from retired entries so embedded metadata cannot make a killed chain look operational
- validate every registry HTTP response before JSON parsing (including Carbon's Keplr registry record) and preserve the existing live-chain Keplr-to-Chain-Registry fallback

## Production semantics

`TokenClient.bridges.ibc` remains sourced from Carbon's `BridgeAll` response and IBC channel/client-state resolution. This change does not rewrite, remove, or disable a bridge because an external registry calls its chain killed.

`ExtendedChainInfo` now exposes two derived fields:

- `registryStatus?: string`: the external Cosmos Chain Registry lifecycle status observed during lookup
- `isTransferAvailable?: boolean`: always populated by `getChainInfoMap`; false only when the Carbon bridge is disabled or the registry explicitly reports `killed`. It remains optional at the type level to avoid breaking downstream object construction.

A missing or unknown registry status is not interpreted as killed. Killed chains retain safe identity/address/currency metadata to avoid breaking current map dereferences, but RPC/REST endpoints, fee currencies, transfer features, and `bestRpcs` are empty. Callers must honor `isTransferAvailable === false` before offering transfers.

## Why the extra Chain Registry status lookup exists

The current `https://chains.cosmos.directory/` aggregate filters out `status: killed` chains. When an on-chain bridge's chain ID is absent from that aggregate, the SDK reads that chain's canonical Chain Registry `chain.json` status before deciding whether to probe Keplr. This prevents the known Stargaze and OmniFlix 404s without a chain-specific denylist.

## Tests

- killed chain does not request its removed Keplr JSON
- killed chain omitted by Cosmos Directory is recognized from Chain Registry before Keplr
- canonical bridge object remains present with its actual enabled value
- retired metadata is present and explicitly unavailable
- killed chains without embedded SDK metadata remain represented with safe, non-operational metadata
- live chain with Keplr metadata loads normally
- live chain missing from Keplr falls back to Cosmos Chain Registry
- missing registry status remains eligible instead of being treated as killed
- explicit unknown registry status remains eligible instead of being treated as killed
- 404 registry responses are not parsed as JSON
- Carbon's non-OK Keplr registry response is not parsed

Verified locally:

- `yarn lint`
- `yarn test` (131/131)

## Coordinated follow-up (not simulated in this SDK)

Current Carbon state still has enabled coin-module IBC bridge records for:

| Chain | Coin bridge key | Carbon channel | Counterparty channel |
|---|---:|---|---|
| Stargaze (`stargaze-1`) | `2.33` | `channel-32` | `channel-279` |
| OmniFlix Hub (`omniflixhub-1`) | `2.20` | `channel-19` | `channel-24` |

These should be retired with Carbon's per-chain coin-module `MsgDeauthorizeBridge` flow (admin/authority or governance execution), not by rewriting SDK state. Before doing so, coordinate asset recovery/migration: Carbon reports an active legacy STARS token (`ibc/C688...F144F`) with non-zero supply, and coin-module withdrawals reject disabled bridges. Demex's remotely configured Stargaze→Noble packet-forward route and Stargaze fee-token metadata must also be removed or gated on `isTransferAvailable` in the same rollout.
