### PR TITLE
deps: force Protobuf.js 7 pending upstream support

### DIFF
--- a/.github/workflows/node24.yml
+++ b/.github/workflows/node24.yml
@@ -48,9 +48,21 @@ jobs:
           yarn install --frozen-lockfile --non-interactive
 
       - name: Check dependency integrity
+        shell: bash
         run: |
+          set -euo pipefail
           yarn check --integrity
-          yarn check --verify-tree
+          set +e
+          verify_output="$(yarn check --verify-tree 2>&1)"
+          verify_status=$?
+          set -e
+          printf '%s\n' "$verify_output"
+          if [ "$verify_status" -ne 0 ]; then
+            expected_errors=$'error "@cosmos-kit/core#@chain-registry/keplr#@keplr-wallet/cosmos#protobufjs" is wrong version: expected "^6.11.2", got "7.6.3"\nerror Found 1 errors.'
+            actual_errors="$(printf '%s\n' "$verify_output" | grep '^error ' || true)"
+            test "$actual_errors" = "$expected_errors"
+            echo 'Accepted the single audited Keplr Protobuf.js override mismatch.'
+          fi
 
       - name: Lint
         run: yarn lint
@@ -74,7 +86,10 @@ jobs:
           npm pack --pack-destination "$package_dir"
           cd "$consumer_dir"
           npm init --yes >/dev/null
+          node -e 'const fs = require("node:fs"); const path = "package.json"; const manifest = JSON.parse(fs.readFileSync(path, "utf8")); manifest.overrides = { "@keplr-wallet/cosmos": { protobufjs: "7.6.3" }, "@keplr-wallet/proto-types": { protobufjs: "7.6.3" } }; fs.writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);'
           npm install --no-audit --no-fund "$package_dir"/carbon-js-sdk-*.tgz
+          npm ls protobufjs --all --json > "$RUNNER_TEMP/protobufjs-tree.json"
+          node -e 'const assert = require("node:assert/strict"); const tree = require(process.argv[1]); const versions = new Set(); const walk = node => { for (const [name, dependency] of Object.entries(node.dependencies || {})) { if (name === "protobufjs") versions.add(dependency.version); walk(dependency); } }; walk(tree); assert.deepEqual([...versions].sort(), ["7.6.3"]);' "$RUNNER_TEMP/protobufjs-tree.json"
           CARBON_SDK_PACKAGE=carbon-js-sdk node --test "$GITHUB_WORKSPACE/tests/package-smoke.test.cjs"
           native_path=$(node -e 'const path=require("node:path"); const root=path.dirname(require.resolve("secp256k1/package.json")); process.stdout.write(require("node-gyp-build").path(root))')
           test "${native_path#*/prebuilds/}" != "$native_path"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,37 @@ The optional `examples/node-ledger.ts` script requires `@ledgerhq/hw-transport-n
 
 `@keplr-wallet/types` declares Starknet as a non-optional peer for its full multi-chain type surface. Carbon JS SDK does not declare Starknet directly because its Keplr integration uses Cosmos-facing declarations only. Yarn 1 leaves that peer unresolved and reports a warning, while npm 7 and newer can auto-install a compatible Starknet release in a consumer project. Avoiding that transitive npm install requires a separate API-contract change that replaces the external Keplr types; adding Starknet directly here would only make unrelated application code an explicit SDK dependency.
 
+## Temporary Protobuf.js application override
+
+Current `@keplr-wallet/cosmos` and `@keplr-wallet/proto-types` releases still request vulnerable `protobufjs@^6.11.2`. Carbon's development lock resolves those owners to audited `protobufjs@7.6.3`, but package-manager root controls are not inherited when an application installs Carbon from npm. Until Keplr publishes Protobuf.js 7-compatible manifests, applications must apply the same temporary override at their own root.
+
+Yarn 1 applications:
+
+```json
+{
+  "resolutions": {
+    "protobufjs": "7.6.3"
+  }
+}
+```
+
+npm applications:
+
+```json
+{
+  "overrides": {
+    "@keplr-wallet/cosmos": {
+      "protobufjs": "7.6.3"
+    },
+    "@keplr-wallet/proto-types": {
+      "protobufjs": "7.6.3"
+    }
+  }
+}
+```
+
+After installation, run `yarn why protobufjs` or `npm ls protobufjs --all` and verify that no Protobuf.js 6 release remains. Remove the override once the Keplr packages declare a compatible Protobuf.js 7 dependency.
+
 ## Testing and CI
 
 Run the deterministic Node test suite with:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "engines": {
     "node": ">=24.0.0 <25"
   },
+  "resolutions": {
+    "protobufjs": "7.6.3"
+  },
   "scripts": {
     "watch": "nodemon --exec \"eslint . && tsc && tsc-alias\"",
     "build": "eslint . && tsc && tsc-alias",
@@ -58,6 +61,7 @@
     "@keplr-wallet/types": "^0.12.207",
     "@ledgerhq/hw-transport": "6.28.8",
     "@ledgerhq/hw-transport-webhid": "^6.20.0",
+    "@types/long": "4.0.1",
     "@ledgerhq/hw-transport-webusb": "^6.20.0",
     "axios": "0.33.0",
     "bech32": "1.1.4",
@@ -76,7 +80,7 @@
     "long": "4.0.0",
     "node-fetch": "2.7.0",
     "node-gyp-build": "4.8.4",
-    "protobufjs": "6.11.4",
+    "protobufjs": "7.6.3",
     "query-string": "^7.0.1",
     "rxjs": "6.6.7",
     "secp256k1": "4.0.4",

--- a/tests/cosmos-wallet-migration.test.cjs
+++ b/tests/cosmos-wallet-migration.test.cjs
@@ -39,7 +39,7 @@ test("Cosmos wallet roots use the audited coherent migration targets", () => {
 test("legacy SecretJS, Axios, Protobuf, and Keplr roots stay removed", () => {
   assert.deepEqual(lockedVersions("secretjs"), []);
   assert.deepEqual(lockedVersions("axios"), ["0.33.0"]);
-  assert.deepEqual(lockedVersions("protobufjs"), ["6.11.4"]);
+  assert.deepEqual(lockedVersions("protobufjs"), ["7.6.3"]);
   assert.doesNotMatch(lockfile, /^"@chain-registry\/keplr@1\.8\.0":$/m);
   assert.doesNotMatch(lockfile, /^"@keplr-wallet\/cosmos@0\.11\.16":$/m);
 });

--- a/tests/direct-import-contracts.test.cjs
+++ b/tests/direct-import-contracts.test.cjs
@@ -25,7 +25,7 @@ const expectedDirectContracts = {
   axios: "0.33.0",
   bech32: "1.1.4",
   long: "4.0.0",
-  protobufjs: "6.11.4",
+  protobufjs: "7.6.3",
   rxjs: "6.6.7",
 };
 

--- a/tests/protobuf-utf8-leaf.test.cjs
+++ b/tests/protobuf-utf8-leaf.test.cjs
@@ -6,6 +6,7 @@ const path = require("node:path");
 const test = require("node:test");
 
 const projectRoot = path.resolve(__dirname, "..");
+const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf8"));
 const lockfile = fs.readFileSync(path.join(projectRoot, "yarn.lock"), "utf8");
 
 function lockedVersions(packageName) {
@@ -18,7 +19,13 @@ function lockedVersions(packageName) {
 }
 
 test("@protobufjs/utf8 has only the audited compatible lock target", () => {
-  assert.deepEqual(lockedVersions("@protobufjs/utf8"), ["1.1.1"]);
+  assert.deepEqual(lockedVersions("@protobufjs/utf8"), ["1.1.2"]);
+});
+
+test("Carbon declares the exact Long 4 public declaration artifact", () => {
+  assert.equal(packageJson.dependencies["@types/long"], "4.0.1");
+  const typesPackage = path.dirname(require.resolve("@types/long/package.json"));
+  assert.equal(fs.existsSync(path.join(typesPackage, "index.d.ts")), true);
 });
 
 test("the patched UTF-8 helper preserves multibyte sizing and round trips", () => {
@@ -42,12 +49,61 @@ test("protobufjs uses the patched UTF-8 helper for message encoding", () => {
   assert.equal(Message.decode(encoded).memo, "Carbon 🚀");
 });
 
-test("protobufjs major-version blockers remain explicit", () => {
+test("Keplr's Protobuf.js 6-generated modules round trip through Protobuf.js 7", () => {
+  const Long = require("long");
+  const { Coin } = require("@keplr-wallet/proto-types/cosmos/base/v1beta1/coin");
+  const { Duration } = require("@keplr-wallet/proto-types/google/protobuf/duration");
+
+  const coin = { denom: "usdc", amount: "123" };
+  const encodedCoin = Coin.encode(coin).finish();
+  assert.deepEqual(Coin.decode(encodedCoin), coin);
+
+  const duration = { seconds: Long.fromString("9007199254740993"), nanos: 7 };
+  const encodedDuration = Duration.encode(duration).finish();
+  const decodedDuration = Duration.decode(encodedDuration);
+  assert.equal(decodedDuration.seconds.toString(), "9007199254740993");
+  assert.equal(decodedDuration.nanos, 7);
+});
+
+function protobufOwners(nodeModules) {
+  const owners = [];
+  const visitPackage = (packageDirectory) => {
+    const manifestPath = path.join(packageDirectory, "package.json");
+    if (!fs.existsSync(manifestPath)) return;
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    if (manifest.dependencies?.protobufjs || manifest.optionalDependencies?.protobufjs) {
+      owners.push(`${manifest.name}@${manifest.version}`);
+    }
+    visitNodeModules(path.join(packageDirectory, "node_modules"));
+  };
+  const visitNodeModules = (directory) => {
+    if (!fs.existsSync(directory)) return;
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name === ".bin") continue;
+      const entryPath = path.join(directory, entry.name);
+      if (entry.name.startsWith("@")) {
+        for (const scopedEntry of fs.readdirSync(entryPath, { withFileTypes: true })) {
+          if (scopedEntry.isDirectory()) visitPackage(path.join(entryPath, scopedEntry.name));
+        }
+      } else {
+        visitPackage(entryPath);
+      }
+    }
+  };
+  visitNodeModules(nodeModules);
+  return owners.sort();
+}
+
+test("protobufjs 7.6.3 is globally resolved only for its audited direct and Keplr owners", () => {
   const versions = [...lockfile.matchAll(/^protobufjs@[^\n]+:\n(?:[ ]{2}[^\n]*\n|[ ]{4}[^\n]*\n)*/gm)]
     .map((match) => match[0].match(/^[ ]{2}version "([^"]+)"$/m)?.[1])
     .filter(Boolean)
     .sort();
 
-  assert.deepEqual(versions, ["6.11.4"]);
-  assert.equal(versions.some((version) => version.startsWith("7.")), false);
+  assert.deepEqual(packageJson.resolutions, { protobufjs: "7.6.3" });
+  assert.deepEqual(versions, ["7.6.3"]);
+  assert.deepEqual(protobufOwners(path.join(projectRoot, "node_modules")), [
+    "@keplr-wallet/cosmos@0.12.28",
+    "@keplr-wallet/proto-types@0.12.28",
+  ]);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,33 +1190,32 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
   integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
 
-"@protobufjs/codegen@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
-  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+"@protobufjs/codegen@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
+  integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
 
-"@protobufjs/eventemitter@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
-  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
 
-"@protobufjs/fetch@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
-  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.1"
-    "@protobufjs/inquire" "^1.1.0"
 
 "@protobufjs/float@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
   integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
 
-"@protobufjs/inquire@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
-  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+"@protobufjs/inquire@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.2.tgz#ae64fbc014ff44c8bfad03dd4c93cd2d6a4c82db"
+  integrity sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==
 
 "@protobufjs/path@^1.1.2":
   version "1.1.2"
@@ -1228,10 +1227,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
   integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
 
-"@protobufjs/utf8@^1.1.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
-  integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
+"@protobufjs/utf8@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.2.tgz#78d476333d85d5b1c792e257bca74ba080da49a4"
+  integrity sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==
 
 "@scure/base@^2.0.0":
   version "2.2.0"
@@ -1298,7 +1297,7 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.174.tgz#b4b06b6eced9850eed6b6a8f1abdd0f5192803c1"
   integrity sha512-KMBLT6+g9qrGXpDt7ohjWPUD34WA/jasrtjTEHStF0NPdEwJ1N9SZ+4GaMVDeuk/y0+X5j9xFm6mNiXS7UoaLQ==
 
-"@types/long@^4.0.1":
+"@types/long@4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
@@ -3024,6 +3023,11 @@ long@4.0.0, long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
+long@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
+
 lru-cache@^10.2.0:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
@@ -3425,24 +3429,23 @@ propagate@^2.0.0:
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
-protobufjs@6.11.4, protobufjs@^6.11.2:
-  version "6.11.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.4.tgz#29a412c38bf70d89e537b6d02d904a6f448173aa"
-  integrity sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==
+protobufjs@7.6.3, protobufjs@^6.11.2:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.3.tgz#92cc8806db61393e68f6a2eb742c1d9c0cafd672"
+  integrity sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
     "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/inquire" "^1.1.2"
     "@protobufjs/path" "^1.1.2"
     "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.1"
+    "@protobufjs/utf8" "^1.1.1"
     "@types/node" ">=13.7.0"
-    long "^4.0.0"
+    long "^5.3.2"
 
 proxy-from-env@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Summary

- migrate Carbon's direct `protobufjs` runtime contract from `6.11.4` to patched `7.6.3`
- temporarily force the two Keplr `protobufjs@^6.11.2` owners to the audited 7.6.3 target in Carbon's Yarn lock
- promote `@types/long@4.0.1` to an exact runtime dependency because Carbon's emitted public declarations use direct `long@4.0.0`
- preserve isolated `long@5.3.2` only under Protobuf.js 7
- document the matching application-root Yarn/npm override required by Disco and other consumers
- keep Yarn tree verification fail-closed while allowing only the single audited Keplr range mismatch
- make packed-consumer CI apply the documented root override and reject any Protobuf.js version other than 7.6.3
- add fail-closed owner and generated-code compatibility tests

## Coordination requirement

**Keep this PR draft until Disco has the matching application-root override.**

Carbon is a published library. Its Yarn `resolutions` field controls this repository's install but is not inherited by applications that install Carbon from npm. Without an application-root override, a packed consumer reinstalls nested `protobufjs@6.11.6` under Keplr.

The README now documents the required temporary root configuration:

- Yarn 1: `resolutions.protobufjs = 7.6.3`
- npm: override Protobuf.js to 7.6.3 under `@keplr-wallet/cosmos` and `@keplr-wallet/proto-types`

A clean packed npm consumer using the documented override resolves **only `protobufjs@7.6.3`** across the complete tree.

## Why an override is required

Current upstream Keplr releases still request Protobuf.js 6:

- `@keplr-wallet/cosmos` → `protobufjs@^6.11.2`
- `@keplr-wallet/proto-types` → `protobufjs@^6.11.2`

The latest and `next` Keplr releases still declare that range. The exact Carbon resolution is guarded by a test that scans the installed graph and fails unless those are the only transitive owners. Remove the workaround once Keplr publishes Protobuf.js 7-compatible manifests.

## Security impact

Projected against Carbon staging after the Ethers security refresh in #648:

- original inventory: 21 alerts
- staging after #648: 13 projected alerts
- staging plus this PR: 2 projected alerts
- projected repository closure: all 11 Protobuf.js advisories

This projection applies to Carbon's lock. Runtime applications require the documented root override for equivalent protection.

## Compatibility evidence

- Protobuf.js 6-generated Keplr `Coin` encoding/decoding passes under 7.6.3
- Keplr `Duration` round-trips a uint64 above JavaScript's safe integer range
- Carbon source compiles with public Long declarations
- Carbon/Keplr retain `long@4.0.0`; only Protobuf.js owns nested `long@5.3.2`
- clean frozen Yarn install reproduces that graph
- clean packed npm consumer with the documented override contains only Protobuf.js 7.6.3
- rebased combined consumer retains `ethers@5.8.0`, safe ws 7/8 targets, and only `elliptic@6.6.1`
- CI's Yarn verifier accepts exactly one known `^6.11.2 -> 7.6.3` mismatch and fails on any additional tree error

## Supply-chain review

Changed artifact families: Protobuf.js helpers, `protobufjs@7.6.3`, `long@5.3.2`, and the existing `@types/long@4.0.1` declaration artifact.

- 8/8 target artifacts have registry integrity metadata
- 8/8 target artifacts have registry signatures
- licenses and repositories match expected upstreams
- no install/prepare hooks except Protobuf.js's `postinstall`
- inspected Protobuf.js postinstall: reads the parent package manifest and may print a version-scheme warning; no network access and no filesystem writes

## Validation

- RED: staging failed target version, resolution, owner, and generated-code contracts
- GREEN: focused Protobuf/Long/Keplr contracts
- script-disabled install + integrity check
- lifecycle-enabled frozen forced install + integrity check
- clean frozen install reproducibility proof
- `yarn tsc --noEmit`
- `yarn lint`
- full Node 24 suite after rebasing onto merged #648: 134/134 tests
- packed npm tarball installed into a disposable strict TypeScript consumer
- packed npm consumer with documented root override: only `protobufjs@7.6.3`
- exact CI integrity-exception parser reproduced locally
- independent fail-closed review of the dependency/test migration: passed with no findings
- consumer-override documentation: reviewed under the repository's approved DaedalusCoder self-review path

## Review focus

- temporary global resolution guard and owner traversal
- explicit application-root coordination requirement
- Protobuf.js 6-generated Keplr compatibility on Protobuf.js 7
- direct `@types/long` placement as a published declaration dependency
- lock graph isolation of long 4 and long 5
