### PR TITLE
deps: force patched ws and uuid leaves

### DIFF
--- a/.github/workflows/node24.yml
+++ b/.github/workflows/node24.yml
@@ -58,10 +58,15 @@ jobs:
           set -e
           printf '%s\n' "$verify_output"
           if [ "$verify_status" -ne 0 ]; then
-            expected_errors=$'error "@cosmos-kit/core#@chain-registry/keplr#@keplr-wallet/cosmos#protobufjs" is wrong version: expected "^6.11.2", got "7.6.3"\nerror Found 1 errors.'
-            actual_errors="$(printf '%s\n' "$verify_output" | grep '^error ' || true)"
+            expected_errors="$(printf '%s\n' \
+              'error "@cosmos-kit/core#@chain-registry/keplr#@keplr-wallet/cosmos#protobufjs" is wrong version: expected "^6.11.2", got "7.6.3"' \
+              'error "@cosmos-kit/core#uuid" is wrong version: expected "^9.0.1", got "11.1.1"' \
+              'error "ethers#@ethersproject/providers#ws" is wrong version: expected "8.18.0", got "8.21.0"' \
+              | sort)"
+            actual_errors="$(printf '%s\n' "$verify_output" | grep '^error "' | sort || true)"
             test "$actual_errors" = "$expected_errors"
-            echo 'Accepted the single audited Keplr Protobuf.js override mismatch.'
+            test "$(printf '%s\n' "$verify_output" | grep '^error Found ' || true)" = 'error Found 3 errors.'
+            echo 'Accepted the three audited dependency override mismatches.'
           fi
 
       - name: Lint
@@ -86,10 +91,10 @@ jobs:
           npm pack --pack-destination "$package_dir"
           cd "$consumer_dir"
           npm init --yes >/dev/null
-          node -e 'const fs = require("node:fs"); const path = "package.json"; const manifest = JSON.parse(fs.readFileSync(path, "utf8")); manifest.overrides = { "@keplr-wallet/cosmos": { protobufjs: "7.6.3" }, "@keplr-wallet/proto-types": { protobufjs: "7.6.3" } }; fs.writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);'
+          node -e 'const fs = require("node:fs"); const path = "package.json"; const manifest = JSON.parse(fs.readFileSync(path, "utf8")); manifest.overrides = { "@ethersproject/providers": { ws: "8.21.0" }, "@keplr-wallet/cosmos": { protobufjs: "7.6.3" }, "@keplr-wallet/proto-types": { protobufjs: "7.6.3" }, uuid: "11.1.1" }; fs.writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);'
           npm install --no-audit --no-fund "$package_dir"/carbon-js-sdk-*.tgz
-          npm ls protobufjs --all --json > "$RUNNER_TEMP/protobufjs-tree.json"
-          node -e 'const assert = require("node:assert/strict"); const tree = require(process.argv[1]); const versions = new Set(); const walk = node => { for (const [name, dependency] of Object.entries(node.dependencies || {})) { if (name === "protobufjs") versions.add(dependency.version); walk(dependency); } }; walk(tree); assert.deepEqual([...versions].sort(), ["7.6.3"]);' "$RUNNER_TEMP/protobufjs-tree.json"
+          npm ls protobufjs uuid ws --all --json > "$RUNNER_TEMP/security-override-tree.json"
+          node -e 'const assert = require("node:assert/strict"); const tree = require(process.argv[1]); const versions = new Map(); const walk = node => { for (const [name, dependency] of Object.entries(node.dependencies || {})) { if (["protobufjs", "uuid", "ws"].includes(name)) { if (!versions.has(name)) versions.set(name, new Set()); versions.get(name).add(dependency.version); } walk(dependency); } }; const atLeast = (version, minimum) => { const actual = version.split(".").map(Number); const target = minimum.split(".").map(Number); return actual[0] > target[0] || actual[0] === target[0] && (actual[1] > target[1] || actual[1] === target[1] && actual[2] >= target[2]); }; walk(tree); const wsVersions = [...(versions.get("ws") || [])]; assert.deepEqual([...(versions.get("protobufjs") || [])].sort(), ["7.6.3"]); assert.deepEqual([...(versions.get("uuid") || [])].sort(), ["11.1.1"]); assert.equal(wsVersions.includes("8.21.0"), true); assert.equal(wsVersions.every(version => version.startsWith("7.") ? atLeast(version, "7.5.11") : version.startsWith("8.") && atLeast(version, "8.21.0")), true);' "$RUNNER_TEMP/security-override-tree.json"
           CARBON_SDK_PACKAGE=carbon-js-sdk node --test "$GITHUB_WORKSPACE/tests/package-smoke.test.cjs"
           native_path=$(node -e 'const path=require("node:path"); const root=path.dirname(require.resolve("secp256k1/package.json")); process.stdout.write(require("node-gyp-build").path(root))')
           test "${native_path#*/prebuilds/}" != "$native_path"

--- a/README.md
+++ b/README.md
@@ -26,16 +26,24 @@ The optional `examples/node-ledger.ts` script requires `@ledgerhq/hw-transport-n
 
 `@keplr-wallet/types` declares Starknet as a non-optional peer for its full multi-chain type surface. Carbon JS SDK does not declare Starknet directly because its Keplr integration uses Cosmos-facing declarations only. Yarn 1 leaves that peer unresolved and reports a warning, while npm 7 and newer can auto-install a compatible Starknet release in a consumer project. Avoiding that transitive npm install requires a separate API-contract change that replaces the external Keplr types; adding Starknet directly here would only make unrelated application code an explicit SDK dependency.
 
-## Temporary Protobuf.js application override
+## Temporary application security overrides
 
-Current `@keplr-wallet/cosmos` and `@keplr-wallet/proto-types` releases still request vulnerable `protobufjs@^6.11.2`. Carbon's development lock resolves those owners to audited `protobufjs@7.6.3`, but package-manager root controls are not inherited when an application installs Carbon from npm. Until Keplr publishes Protobuf.js 7-compatible manifests, applications must apply the same temporary override at their own root.
+Current upstream manifests still request vulnerable dependency targets:
+
+- `@keplr-wallet/cosmos` and `@keplr-wallet/proto-types` request `protobufjs@^6.11.2`.
+- `@ethersproject/providers@5.8.0` requests exact `ws@8.18.0`.
+- `@cosmos-kit/core` and `@dao-dao/cosmiframe` request `uuid@^9.0.1`.
+
+Carbon's development lock resolves those owners to audited patched targets, but package-manager root controls are not inherited when an application installs Carbon from npm. Until upstream packages publish compatible manifests, applications must apply the same temporary overrides at their own root.
 
 Yarn 1 applications:
 
 ```json
 {
   "resolutions": {
-    "protobufjs": "7.6.3"
+    "**/@ethersproject/providers/ws": "8.21.0",
+    "protobufjs": "7.6.3",
+    "uuid": "11.1.1"
   }
 }
 ```
@@ -45,17 +53,25 @@ npm applications:
 ```json
 {
   "overrides": {
+    "@ethersproject/providers": {
+      "ws": "8.21.0"
+    },
     "@keplr-wallet/cosmos": {
       "protobufjs": "7.6.3"
     },
     "@keplr-wallet/proto-types": {
       "protobufjs": "7.6.3"
-    }
+    },
+    "uuid": "11.1.1"
   }
 }
 ```
 
-After installation, run `yarn why protobufjs` or `npm ls protobufjs --all` and verify that no Protobuf.js 6 release remains. Remove the override once the Keplr packages declare a compatible Protobuf.js 7 dependency.
+After installation, inspect the complete trees with `yarn why protobufjs`, `yarn why uuid`, and `yarn why ws`, or with `npm ls protobufjs uuid ws --all`. Verify that Protobuf.js 6, uuid versions below 11.1.1, and ws 8 versions below 8.21.0 are absent. Remove each override once its upstream owner declares a compatible patched dependency.
+
+### Residual elliptic advisory
+
+The remaining low-severity `elliptic` advisory ([GHSA-848j-6mx2-7j84](https://github.com/advisories/GHSA-848j-6mx2-7j84)) currently affects every available release through 6.6.1 and has no patched version. Carbon retains exact `elliptic@6.6.1` through several wallet and signing owners, with deterministic secp256k1 behavior covered by the test suite. Removing the package requires coordinated migrations of those owners; a lockfile-only override or alert dismissal would not remediate the advisory, so the alert remains open until a genuine upstream or structural fix is available.
 
 ## Testing and CI
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "node": ">=24.0.0 <25"
   },
   "resolutions": {
-    "protobufjs": "7.6.3"
+    "**/@ethersproject/providers/ws": "8.21.0",
+    "protobufjs": "7.6.3",
+    "uuid": "11.1.1"
   },
   "scripts": {
     "watch": "nodemon --exec \"eslint . && tsc && tsc-alias\"",

--- a/tests/protobuf-utf8-leaf.test.cjs
+++ b/tests/protobuf-utf8-leaf.test.cjs
@@ -100,7 +100,11 @@ test("protobufjs 7.6.3 is globally resolved only for its audited direct and Kepl
     .filter(Boolean)
     .sort();
 
-  assert.deepEqual(packageJson.resolutions, { protobufjs: "7.6.3" });
+  assert.deepEqual(packageJson.resolutions, {
+    "**/@ethersproject/providers/ws": "8.21.0",
+    protobufjs: "7.6.3",
+    uuid: "11.1.1",
+  });
   assert.deepEqual(versions, ["7.6.3"]);
   assert.deepEqual(protobufOwners(path.join(projectRoot, "node_modules")), [
     "@keplr-wallet/cosmos@0.12.28",

--- a/tests/residual-compatible-leaves.test.cjs
+++ b/tests/residual-compatible-leaves.test.cjs
@@ -27,10 +27,10 @@ test("the coherent Ethers v5 family removes its vulnerable exact elliptic blocke
 });
 
 test("the Ethers provider uses patched ws 8 while Carbon retains its compatible ws 7 contract", () => {
-  assert.deepEqual(lockedVersions("ws"), ["7.5.11", "8.18.0"]);
+  assert.deepEqual(lockedVersions("ws"), ["7.5.11", "8.21.0"]);
   assert.doesNotMatch(lockfile, /^ws@7\.4\.6:/m);
   assert.match(lockfile, /^ws@\^7, ws@\^7\.5\.11:\n[ ]{2}version "7\.5\.11"$/m);
-  assert.match(lockfile, /^ws@8\.18\.0:\n[ ]{2}version "8\.18\.0"$/m);
+  assert.match(lockfile, /^ws@8\.18\.0, ws@8\.21\.0:\n[ ]{2}version "8\.21\.0"$/m);
 });
 
 test("elliptic 6.6.1 preserves deterministic secp256k1 signing", () => {
@@ -107,7 +107,7 @@ test("Ethers 5.8 WebSocketProvider interoperates with local JSON-RPC through its
       path.dirname(require.resolve("@ethersproject/providers/package.json")),
       "node_modules/ws/package.json",
     );
-    assert.equal(JSON.parse(fs.readFileSync(nestedWsPackage, "utf8")).version, "8.18.0");
+    assert.equal(JSON.parse(fs.readFileSync(nestedWsPackage, "utf8")).version, "8.21.0");
   } finally {
     await provider.destroy();
     await new Promise((resolve) => server.close(resolve));

--- a/tests/uuid-security-override.test.cjs
+++ b/tests/uuid-security-override.test.cjs
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global Buffer, __dirname, require */
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const projectRoot = path.resolve(__dirname, "..");
+const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf8"));
+const lockfile = fs.readFileSync(path.join(projectRoot, "yarn.lock"), "utf8");
+
+function lockedVersions(packageName) {
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const stanza = new RegExp(`^"?${escaped}@[^\n]+:\\n(?:[ ]{2}[^\n]*\\n|[ ]{4}[^\n]*\\n)*`, "gm");
+  return [...lockfile.matchAll(stanza)]
+    .map((match) => match[0].match(/^[ ]{2}version "([^"]+)"$/m)?.[1])
+    .filter(Boolean)
+    .sort();
+}
+
+function dependencyOwners(dependencyName, nodeModules) {
+  const owners = [];
+  const visitPackage = (packageDirectory) => {
+    const manifestPath = path.join(packageDirectory, "package.json");
+    if (!fs.existsSync(manifestPath)) return;
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    if (manifest.dependencies?.[dependencyName] || manifest.optionalDependencies?.[dependencyName]) {
+      owners.push(`${manifest.name}@${manifest.version}`);
+    }
+    visitNodeModules(path.join(packageDirectory, "node_modules"));
+  };
+  const visitNodeModules = (directory) => {
+    if (!fs.existsSync(directory)) return;
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name === ".bin") continue;
+      const entryPath = path.join(directory, entry.name);
+      if (entry.name.startsWith("@")) {
+        for (const scopedEntry of fs.readdirSync(entryPath, { withFileTypes: true })) {
+          if (scopedEntry.isDirectory()) visitPackage(path.join(entryPath, scopedEntry.name));
+        }
+      } else {
+        visitPackage(entryPath);
+      }
+    }
+  };
+  visitNodeModules(nodeModules);
+  return owners.sort();
+}
+
+test("uuid 11.1.1 is globally resolved only for the audited Cosmos Kit owners", () => {
+  assert.equal(packageJson.resolutions.uuid, "11.1.1");
+  assert.deepEqual(lockedVersions("uuid"), ["11.1.1"]);
+  assert.deepEqual(dependencyOwners("uuid", path.join(projectRoot, "node_modules")), [
+    "@cosmos-kit/core@2.18.1",
+    "@dao-dao/cosmiframe@1.0.0",
+  ]);
+});
+
+test("uuid 11 preserves wallet identifiers and rejects undersized output buffers", () => {
+  const uuid = require("uuid");
+  const random = uuid.v4();
+  const output = Buffer.alloc(16);
+
+  assert.equal(require("uuid/package.json").version, "11.1.1");
+  assert.equal(uuid.validate(random), true);
+  assert.equal(uuid.v5("carbon-sdk", uuid.v5.DNS, output, 0), output);
+  assert.equal(uuid.validate(uuid.stringify(output)), true);
+  assert.throws(
+    () => uuid.v5("carbon-sdk", uuid.v5.DNS, Buffer.alloc(15), 0),
+    /buffer|bounds|16 byte/i,
+  );
+});

--- a/tests/uuid-security-override.test.cjs
+++ b/tests/uuid-security-override.test.cjs
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-/* global Buffer, __dirname, require */
+/* global Buffer, __dirname, global, queueMicrotask, require */
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
@@ -48,15 +48,25 @@ function dependencyOwners(dependencyName, nodeModules) {
 }
 
 test("uuid 11.1.1 is globally resolved only for the audited Cosmos Kit owners", () => {
+  const coreDirectory = path.dirname(require.resolve("@cosmos-kit/core/package.json"));
+  const cosmiframeDirectory = path.dirname(
+    require.resolve("@dao-dao/cosmiframe/package.json", { paths: [coreDirectory] }),
+  );
+
   assert.equal(packageJson.resolutions.uuid, "11.1.1");
   assert.deepEqual(lockedVersions("uuid"), ["11.1.1"]);
   assert.deepEqual(dependencyOwners("uuid", path.join(projectRoot, "node_modules")), [
     "@cosmos-kit/core@2.18.1",
     "@dao-dao/cosmiframe@1.0.0",
   ]);
+  assert.ok(Object.keys(require("@cosmos-kit/core")).length > 0);
+  for (const ownerDirectory of [coreDirectory, cosmiframeDirectory]) {
+    const uuidPackage = require.resolve("uuid/package.json", { paths: [ownerDirectory] });
+    assert.equal(require(uuidPackage).version, "11.1.1");
+  }
 });
 
-test("uuid 11 preserves wallet identifiers and rejects undersized output buffers", () => {
+test("uuid 11 preserves wallet identifiers and rejects every vulnerable partial-write path", () => {
   const uuid = require("uuid");
   const random = uuid.v4();
   const output = Buffer.alloc(16);
@@ -65,8 +75,59 @@ test("uuid 11 preserves wallet identifiers and rejects undersized output buffers
   assert.equal(uuid.validate(random), true);
   assert.equal(uuid.v5("carbon-sdk", uuid.v5.DNS, output, 0), output);
   assert.equal(uuid.validate(uuid.stringify(output)), true);
-  assert.throws(
-    () => uuid.v5("carbon-sdk", uuid.v5.DNS, Buffer.alloc(15), 0),
-    /buffer|bounds|16 byte/i,
-  );
+  const partialWrites = [
+    () => uuid.v3("carbon-sdk", uuid.v3.DNS, Buffer.alloc(8), 4),
+    () => uuid.v5("carbon-sdk", uuid.v5.DNS, Buffer.alloc(8), 4),
+    () => uuid.v6({}, Buffer.alloc(8), 4),
+  ];
+  for (const write of partialWrites) {
+    assert.throws(write, (error) => error instanceof RangeError);
+  }
+});
+
+test("cosmiframe correlates a real request through uuid 11's CommonJS v4 API", async () => {
+  const coreDirectory = path.dirname(require.resolve("@cosmos-kit/core/package.json"));
+  const cosmiframePackage = require.resolve("@dao-dao/cosmiframe", { paths: [coreDirectory] });
+  const cosmiframe = require(cosmiframePackage);
+  const listeners = new Set();
+  let request;
+  const parent = {
+    postMessage(data) {
+      request = data;
+      queueMicrotask(() => {
+        for (const listener of listeners) {
+          listener({
+            origin: "https://wallet.example",
+            source: parent,
+            data: { id: data.id, type: "success", response: "ack" },
+          });
+        }
+      });
+    },
+  };
+  global.window = {
+    parent,
+    addEventListener(type, listener) {
+      if (type === "message") listeners.add(listener);
+    },
+    removeEventListener(type, listener) {
+      if (type === "message") listeners.delete(listener);
+    },
+  };
+
+  try {
+    const result = await cosmiframe.callParentMethod(
+      { method: "getKey", params: ["carbon-1"] },
+      ["https://wallet.example"],
+      100,
+    );
+    assert.match(
+      request.id,
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    assert.deepEqual(result, { result: "ack", origin: "https://wallet.example" });
+    assert.equal(listeners.size, 0);
+  } finally {
+    delete global.window;
+  }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3984,10 +3984,10 @@ utility-types@^3.10.0:
   resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.11.0.tgz#607c40edb4f258915e901ea7995607fdf319424c"
   integrity sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==
 
-uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+uuid@11.1.1, uuid@^9.0.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
@@ -4044,10 +4044,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@8.18.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+ws@8.18.0, ws@8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 ws@^7, ws@^7.5.11:
   version "7.5.11"


### PR DESCRIPTION
## Summary

- force only the Ethers 5 provider path from vulnerable `ws@8.18.0` to patched `ws@8.21.0`
- force the audited Cosmos Kit/cosmiframe owners from vulnerable `uuid@9.0.1` to patched `uuid@11.1.1`
- preserve Carbon/CosmJS's separate ws 7 compatibility contract
- extend fail-closed tree verification and packed-consumer checks to all coordinated overrides
- document the required application-root controls and the residual no-patch Elliptic advisory

## Why

Two new ws advisories affect Ethers 5.8's exact `ws@8.18.0` dependency, with fixed versions starting at 8.20.1 and 8.21.0. The existing Carbon uuid alert affects versions below 11.1.1 through `@cosmos-kit/core` and `@dao-dao/cosmiframe`.

Yarn resolutions in a library package do not propagate into applications that install Carbon. Controlled applications must declare matching root overrides. The owner selector is intentionally `**/@ethersproject/providers/ws`; `**/ethers/ws` does not reach the nested provider dependency and leaves 8.18.0 installed.

## Dependency graph

- Ethers provider ws: `8.18.0 -> 8.21.0`
- Cosmos Kit/cosmiframe uuid: `9.0.1 -> 11.1.1`
- Carbon/CosmJS ws: remains on compatible 7.5.x
- Protobuf.js: remains on the existing coordinated 7.6.3 target
- Elliptic: remains at 6.6.1 because GHSA-848j-6mx2-7j84 has no patched release and is owned by multiple wallet/signing paths

## Validation

- Node: 24.18.0
- Yarn: 1.22.22
- clean frozen install with scripts disabled: passed
- clean frozen install with lifecycle scripts: passed
- integrity gate: passed
- fail-closed exact three-mismatch tree gate: passed
- ESLint: passed
- complete suite: 137/137 passed
- Ethers WebSocketProvider local JSON-RPC integration: passed with owner-relative ws 8.21.0
- uuid v3/v5/v6 advisory buffer-bounds behavior: passed
- direct Cosmos Kit loading and exact owner-relative uuid resolution: passed
- real cosmiframe v4 request/response correlation: passed
- exact owner traversal: passed
- packed npm consumer with matching root overrides: passed
- packed consumer package smoke: 6/6 passed
- packed consumer effective versions:
  - `protobufjs`: only 7.6.3
  - `uuid`: only 11.1.1
  - `ws`: 7.5.12 and 8.21.0

## Supply-chain review

Both new targets use signed npm registry artifacts with lockfile-matching integrity values, MIT licenses, canonical upstream repositories, and no registry install/postinstall hooks.

## Alert projection

This should close the two current ws alerts and the uuid alert. The single low-severity Elliptic alert remains open because there is no patched version; removing it requires a separate multi-root wallet and cryptography migration rather than a lockfile-only change.
