### PR TITLE
deps: migrate to maintained MetaMask signing utility

### DIFF
--- a/.github/workflows/node24.yml
+++ b/.github/workflows/node24.yml
@@ -59,12 +59,13 @@ jobs:
           printf '%s\n' "$verify_output"
           if [ "$verify_status" -ne 0 ]; then
             expected_errors="$(printf '%s\n' \
+              'error "@metamask/eth-sig-util#@metamask/utils#uuid" is wrong version: expected "^9.0.1", got "11.1.1"' \
               'error "ethers#@ethersproject/providers#ws" is wrong version: expected "8.18.0", got "8.21.0"' \
               | sort)"
             actual_errors="$(printf '%s\n' "$verify_output" | grep '^error "' | sort || true)"
             test "$actual_errors" = "$expected_errors"
-            test "$(printf '%s\n' "$verify_output" | grep '^error Found ' || true)" = 'error Found 1 errors.'
-            echo 'Accepted the single audited Ethers ws override mismatch.'
+            test "$(printf '%s\n' "$verify_output" | grep '^error Found ' || true)" = 'error Found 2 errors.'
+            echo 'Accepted the audited MetaMask uuid and Ethers ws override mismatches.'
           fi
 
       - name: Lint
@@ -89,8 +90,8 @@ jobs:
           npm pack --pack-destination "$package_dir"
           cd "$consumer_dir"
           npm init --yes >/dev/null
-          node -e 'const fs = require("node:fs"); const path = "package.json"; const manifest = JSON.parse(fs.readFileSync(path, "utf8")); manifest.overrides = { "@ethersproject/providers": { ws: "8.21.0" } }; fs.writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);'
+          node -e 'const fs = require("node:fs"); const path = "package.json"; const manifest = JSON.parse(fs.readFileSync(path, "utf8")); manifest.overrides = { "@ethersproject/providers": { ws: "8.21.0" }, uuid: "11.1.1" }; fs.writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);'
           npm install --no-audit --no-fund "$package_dir"/carbon-js-sdk-*.tgz
-          npm ls protobufjs ws --all --json > "$RUNNER_TEMP/security-override-tree.json"
-          node -e 'const assert = require("node:assert/strict"); const tree = require(process.argv[1]); const versions = new Map(); const walk = node => { for (const [name, dependency] of Object.entries(node.dependencies || {})) { if (["protobufjs", "ws"].includes(name)) { if (!versions.has(name)) versions.set(name, new Set()); versions.get(name).add(dependency.version); } walk(dependency); } }; const atLeast = (version, minimum) => { const actual = version.split(".").map(Number); const target = minimum.split(".").map(Number); return actual[0] > target[0] || actual[0] === target[0] && (actual[1] > target[1] || actual[1] === target[1] && actual[2] >= target[2]); }; walk(tree); const wsVersions = [...(versions.get("ws") || [])]; assert.deepEqual([...(versions.get("protobufjs") || [])].sort(), ["7.6.3"]); assert.equal(wsVersions.includes("8.21.0"), true); assert.equal(wsVersions.every(version => version.startsWith("7.") ? atLeast(version, "7.5.11") : version.startsWith("8.") && atLeast(version, "8.21.0")), true);' "$RUNNER_TEMP/security-override-tree.json"
+          npm ls protobufjs uuid ws --all --json > "$RUNNER_TEMP/security-override-tree.json"
+          node -e 'const assert = require("node:assert/strict"); const tree = require(process.argv[1]); const versions = new Map(); const walk = node => { for (const [name, dependency] of Object.entries(node.dependencies || {})) { if (["protobufjs", "uuid", "ws"].includes(name)) { if (!versions.has(name)) versions.set(name, new Set()); versions.get(name).add(dependency.version); } walk(dependency); } }; const atLeast = (version, minimum) => { const actual = version.split(".").map(Number); const target = minimum.split(".").map(Number); return actual[0] > target[0] || actual[0] === target[0] && (actual[1] > target[1] || actual[1] === target[1] && actual[2] >= target[2]); }; walk(tree); const wsVersions = [...(versions.get("ws") || [])]; assert.deepEqual([...(versions.get("protobufjs") || [])].sort(), ["7.6.3"]); assert.deepEqual([...(versions.get("uuid") || [])].sort(), ["11.1.1"]); assert.equal(wsVersions.includes("8.21.0"), true); assert.equal(wsVersions.every(version => version.startsWith("7.") ? atLeast(version, "7.5.11") : version.startsWith("8.") && atLeast(version, "8.21.0")), true);' "$RUNNER_TEMP/security-override-tree.json"
           CARBON_SDK_PACKAGE=carbon-js-sdk node --test "$GITHUB_WORKSPACE/tests/package-smoke.test.cjs"

--- a/README.md
+++ b/README.md
@@ -28,16 +28,20 @@ The optional `examples/node-ledger.ts` script requires `@ledgerhq/hw-transport-n
 
 ## Temporary application security overrides
 
-`@ethersproject/providers@5.8.0` requests exact `ws@8.18.0`.
+Two upstream owners still request vulnerable dependency ranges:
 
-Carbon's development lock resolves that package to the audited patched target, but package-manager root controls are not inherited when an application installs Carbon from npm. Applications must apply the same temporary override at their own root.
+- `@ethersproject/providers@5.8.0` requests exact `ws@8.18.0`.
+- `@metamask/utils@11.11.0` requests `uuid@^9.0.1`.
+
+Carbon's development lock resolves these packages to audited patched targets, but package-manager root controls are not inherited when an application installs Carbon from npm. Applications must apply the same temporary overrides at their own root.
 
 Yarn 1 applications:
 
 ```json
 {
   "resolutions": {
-    "**/@ethersproject/providers/ws": "8.21.0"
+    "**/@ethersproject/providers/ws": "8.21.0",
+    "uuid": "11.1.1"
   }
 }
 ```
@@ -49,12 +53,13 @@ npm applications:
   "overrides": {
     "@ethersproject/providers": {
       "ws": "8.21.0"
-    }
+    },
+    "uuid": "11.1.1"
   }
 }
 ```
 
-After installation, inspect the complete tree with `yarn why ws` or `npm ls ws --all`. Verify that ws 8 versions below 8.21.0 are absent. Remove the override once its upstream owner declares a compatible patched dependency.
+After installation, inspect the complete trees with `yarn why uuid`, `yarn why ws`, or `npm ls uuid ws --all`. Verify that UUID versions below 11.1.1 and ws 8 versions below 8.21.0 are absent. Remove each override once its upstream owner declares a compatible patched dependency.
 
 ### Residual elliptic advisory
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "node": ">=24.0.0 <25"
   },
   "resolutions": {
-    "**/@ethersproject/providers/ws": "8.21.0"
+    "**/@ethersproject/providers/ws": "8.21.0",
+    "uuid": "11.1.1"
   },
   "scripts": {
     "watch": "nodemon --exec \"eslint . && tsc && tsc-alias\"",
@@ -59,6 +60,7 @@
     "@keplr-wallet/types": "^0.12.207",
     "@ledgerhq/hw-transport": "6.28.8",
     "@ledgerhq/hw-transport-webhid": "^6.20.0",
+    "@metamask/eth-sig-util": "8.2.0",
     "@types/long": "4.0.1",
     "@ledgerhq/hw-transport-webusb": "^6.20.0",
     "@noble/curves": "1.9.7",
@@ -70,7 +72,6 @@
     "cosmjs-types": "0.11.0",
     "crypto-js": "4.2.0",
     "dayjs": "^1.10.5",
-    "eth-sig-util": "^3.0.1",
     "ethers": "5.8.0",
     "google-protobuf": "3.21.4",
     "jwt-decode": "^4.0.0",

--- a/src/provider/metamask/MetaMask.ts
+++ b/src/provider/metamask/MetaMask.ts
@@ -18,8 +18,8 @@ import { CarbonSigner, CarbonSignerTypes } from "@carbon-sdk/wallet";
 import { AminoMsg, makeSignDoc } from "@cosmjs/amino";
 import { Algo, EncodeObject, makeSignDoc as makeProtoSignDoc, TxBodyEncodeObject } from "@cosmjs/proto-signing";
 import { StdFee } from "@cosmjs/stargate";
+import { encrypt } from "@metamask/eth-sig-util";
 import { TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx";
-import * as ethSignUtils from "eth-sig-util";
 import { ethers } from "ethers";
 import { CARBON_EVM_DEVNET, CARBON_EVM_LOCALHOST, CARBON_EVM_MAINNET, CARBON_EVM_TESTNET, ChangeNetworkParam as MetaMaskChangeNetworkParam, ETH_MAINNET, ETH_TESTNET } from "../../constant";
 import { Eip6963Provider } from "../eip6963Provider";
@@ -539,13 +539,11 @@ export class MetaMask extends Eip6963Provider {
 
     const messageToEncrypt = getEncryptMessage(mnemonic);
 
-    const cipher = ethSignUtils.encrypt(
+    const cipher = encrypt({
       publicKey,
-      {
-        data: messageToEncrypt,
-      },
-      ENCRYPTION_VERSION
-    );
+      data: messageToEncrypt,
+      version: ENCRYPTION_VERSION,
+    });
 
     const { version, nonce, ephemPublicKey, ciphertext } = cipher;
     const encryptedMnemonic = ethers.utils.toUtf8Bytes([version, nonce, ephemPublicKey, ciphertext].join("."));

--- a/tests/cosmos-kit-pruning.test.cjs
+++ b/tests/cosmos-kit-pruning.test.cjs
@@ -73,18 +73,17 @@ test("Cosmos Kit roots and their transitive owner family are absent", () => {
   }
 });
 
-test("the removed Cosmos Kit family leaves no uuid owner or override", () => {
-  assert.equal(manifest.resolutions.uuid, undefined);
-  assert.deepEqual(lockedVersions("uuid"), []);
-  assert.deepEqual(dependencyOwners("uuid", path.join(projectRoot, "node_modules")), []);
+test("the removed Cosmos Kit family leaves only the audited MetaMask uuid owner", () => {
+  assert.equal(manifest.resolutions.uuid, "11.1.1");
+  assert.deepEqual(lockedVersions("uuid"), ["11.1.1"]);
+  assert.deepEqual(dependencyOwners("uuid", path.join(projectRoot, "node_modules")), [
+    "@metamask/utils@11.11.0",
+  ]);
 });
 
 test("remaining elliptic owners exclude the Cosmos Kit Keplr family", () => {
   assert.deepEqual(dependencyOwners("elliptic", path.join(projectRoot, "node_modules")), [
     "@ethersproject/signing-key@5.8.0",
-    "ethereumjs-util@5.2.1",
-    "ethereumjs-util@6.2.1",
-    "secp256k1@4.0.4",
   ]);
 });
 

--- a/tests/metamask-eth-sig-util.test.cjs
+++ b/tests/metamask-eth-sig-util.test.cjs
@@ -1,0 +1,282 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global Buffer, __dirname, console, global, require */
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const projectRoot = path.resolve(__dirname, "..");
+const manifest = require(path.join(projectRoot, "package.json"));
+const lockfile = fs.readFileSync(path.join(projectRoot, "yarn.lock"), "utf8");
+
+if (!global.window) {
+  global.window = {
+    addEventListener() {},
+    dispatchEvent() {},
+  };
+}
+
+const { Network } = require(path.join(projectRoot, "lib/constant"));
+const { MetaMask } = require(path.join(projectRoot, "lib/provider/metamask/MetaMask"));
+
+const PRIVATE_KEY = "4f3edf983ac636a65a842ce7c78d9aa706d3b113bce036f33285f1f4b6f7f6f5";
+const ACCOUNT = "0x83f3feF2b80Ebadf59416069AAA99DcD814E0C5A";
+const ENCRYPTION_PUBLIC_KEY = "+BF+3cz5lAMXI7weV+UwylVqShuaA/P5pWExdupqajU=";
+const MNEMONIC = "test test test test test test test test test test test junk";
+const ENCRYPTED_MESSAGE = [
+  "!!! Attention !!! Please make sure you are connecting to https://app.dem.exchange, do not confirm decrypt if you're connecting to untrusted sites.",
+  "-----BEGIN MNEMONIC PHRASE-----",
+  MNEMONIC,
+  "-----END MNEMONIC PHRASE-----",
+].join("\n");
+
+function createMetaMask() {
+  return new MetaMask(Network.MainNet, false);
+}
+
+test("the maintained MetaMask signing utility replaces the deprecated package exactly", () => {
+  assert.equal(manifest.dependencies["@metamask/eth-sig-util"], "8.2.0");
+  assert.equal(manifest.dependencies["eth-sig-util"], undefined);
+  assert.match(lockfile, /^"?@metamask\/eth-sig-util@8\.2\.0"?:$/m);
+  assert.doesNotMatch(lockfile, /^eth-sig-util@/m);
+  assert.equal(manifest.resolutions.uuid, "11.1.1");
+  const metamaskUtilsDirectory = path.dirname(require.resolve("@metamask/utils/package.json"));
+  const uuidManifest = require(require.resolve("uuid/package.json", { paths: [metamaskUtilsDirectory] }));
+  assert.equal(uuidManifest.version, "11.1.1");
+});
+
+test("the deprecated ethereumjs-util 5 owner path is absent without claiming all elliptic is gone", () => {
+  assert.doesNotMatch(lockfile, /^ethereumjs-util@\^5\.1\.1:$/m);
+  assert.doesNotMatch(lockfile, /^ethereumjs-util@[^\n]*\^5\.1\.1[^\n]*:$/m);
+  assert.doesNotMatch(lockfile, /^ethereumjs-util@/m);
+  assert.doesNotMatch(lockfile, /^eth-sig-util@/m);
+  for (const packageName of ["eth-sig-util", "ethereumjs-util"]) {
+    assert.throws(
+      () => require.resolve(packageName, { paths: [projectRoot] }),
+      (error) => error.code === "MODULE_NOT_FOUND",
+    );
+  }
+  assert.match(lockfile, /^elliptic@/m);
+});
+
+test("MetaMask mnemonic encryption keeps the stored cipher format and decrypts with the maintained API", async () => {
+  const { decrypt, getEncryptionPublicKey } = require("@metamask/eth-sig-util");
+  assert.equal(getEncryptionPublicKey(PRIVATE_KEY), ENCRYPTION_PUBLIC_KEY);
+
+  const legacyCipher = {
+    version: "x25519-xsalsa20-poly1305",
+    nonce: "SPUyX+4JngOdZNBo8OjgBpwSpYhrr1FA",
+    ephemPublicKey: "6XeLxeawgGvm7A4fQ6L9xYPgc5K/7XGgjydB8lvfygE=",
+    ciphertext: "qSkef4hXP5rJTAQ1J7PZ+HzuyKXTtfeQtnP7JlrB2nAXiImriex4qDU3CJv9u3Iq6wdUCg/MLMwihmG3txAPeM27uXLnBl1TJBk6PYguRro44Bzre+toSwMzqss3hFFGGlwuYErF5NvQdbJurnBeBSRpAZO+Wt1nqIoB0V+GShpRdLY+QIV5O5ISIdqL6tNd5sMg6DEJh7emGxsD5GH0ykv3V+pKtPe+8EhZVH55ScP5cqgIiomY2VQms9yXpeBo2VJ4a7U5U1N7EAeQdVJoGZ7U3s2tU+1FeT7VYCsmR9YSQpBd5BKq98nTzz+aeAkt9CcnMNghmQjiGcTLkWUkO3m6h62AIDD8FhKiG7i+3fAFhQo7OSXPHYTwnbE=",
+  };
+  assert.equal(decrypt({ encryptedData: legacyCipher, privateKey: PRIVATE_KEY }), ENCRYPTED_MESSAGE);
+
+  const metamask = createMetaMask();
+  metamask.defaultAccount = async () => ACCOUNT;
+  metamask.getEncryptionPublicKey = async (address) => {
+    assert.equal(address, ACCOUNT);
+    return ENCRYPTION_PUBLIC_KEY;
+  };
+
+  const storedCipherHex = await metamask.encryptMnemonic(MNEMONIC);
+  const [version, nonce, ephemPublicKey, ciphertext] = Buffer.from(storedCipherHex, "hex").toString("utf8").split(".");
+
+  assert.equal(version, "x25519-xsalsa20-poly1305");
+  assert.ok(nonce);
+  assert.ok(ephemPublicKey);
+  assert.ok(ciphertext);
+  assert.equal(
+    decrypt({ encryptedData: { version, nonce, ephemPublicKey, ciphertext }, privateKey: PRIVATE_KEY }),
+    ENCRYPTED_MESSAGE,
+  );
+});
+
+test("MetaMask decryption preserves modern and legacy stored mnemonic workflows", async (t) => {
+  for (const [name, decryptedValue, expected] of [
+    ["warning-wrapped", ENCRYPTED_MESSAGE, MNEMONIC],
+    ["legacy plaintext", MNEMONIC, MNEMONIC],
+  ]) {
+    await t.test(name, async () => {
+      const calls = [];
+      const metamask = createMetaMask();
+      metamask.defaultAccount = async () => ACCOUNT;
+      metamask.getConnectedAPI = async () => ({
+        request: async (request) => {
+          calls.push(request);
+          return decryptedValue;
+        },
+      });
+      const cipher = {
+        version: "x25519-xsalsa20-poly1305",
+        nonce: "bm9uY2U=",
+        ephemPublicKey: "cHVibGljLWtleQ==",
+        ciphertext: "Y2lwaGVydGV4dA==",
+      };
+      const cipherHex = Buffer.from(Object.values(cipher).join("."), "utf8").toString("hex");
+
+      assert.equal(await metamask.decryptCipher(`0x${cipherHex}`), expected);
+      assert.deepEqual(calls, [
+        {
+          method: "eth_decrypt",
+          params: [Buffer.from(JSON.stringify(cipher)).toString("hex"), ACCOUNT],
+        },
+      ]);
+    });
+  }
+});
+
+test("MetaMask decryption rejects non-mnemonic plaintext", async () => {
+  const metamask = createMetaMask();
+  metamask.defaultAccount = async () => ACCOUNT;
+  metamask.getConnectedAPI = async () => ({ request: async () => "not-a-mnemonic!" });
+  const cipherHex = Buffer.from("x25519-xsalsa20-poly1305.nonce.public.ciphertext", "utf8").toString("hex");
+
+  const errors = [];
+  const originalConsoleError = console.error;
+  console.error = (...args) => errors.push(args);
+  try {
+    await assert.rejects(
+      metamask.decryptCipher(`0x${cipherHex}`),
+      /Retrieved invalid account on blockchain/,
+    );
+  } finally {
+    console.error = originalConsoleError;
+  }
+  assert.equal(errors.length, 2);
+});
+
+test("MetaMask personal_sign preserves UTF-8 hex payload and checksum address ordering", async () => {
+  const calls = [];
+  const metamask = createMetaMask();
+  metamask.getConnectedAPI = async () => ({
+    request: async (request) => {
+      calls.push(request);
+      return "0x" + "11".repeat(65);
+    },
+  });
+
+  const signature = await metamask.personalSign(ACCOUNT.toLowerCase(), "Carbon ✓");
+
+  assert.equal(signature, "0x" + "11".repeat(65));
+  assert.deepEqual(calls, [
+    {
+      method: "personal_sign",
+      params: ["0x436172626f6e20e29c93", ACCOUNT],
+    },
+  ]);
+});
+
+test("MetaMask public-key recovery preserves the production personal-sign vector", async () => {
+  const message = "carbon-sdk MetaMask recovery vector";
+  const signature = "0x1b475b12d12ffc552c1c5274ac21921ef0cba53d0b33304b8ff475b484089e711c54a82a75de9d80a63ea5c3b652ec14c01af5a0f9787a371bf6e60faac9043e1b";
+  const expectedPublicKey = "AqNTs+t5KaFSvNb8awSU28gTissaM7fv1AeNO1WwOijv";
+  const calls = [];
+  const provider = {
+    defaultAccount: async () => ACCOUNT,
+    personalSign: async (address, data) => {
+      calls.push({ address, data });
+      return signature;
+    },
+  };
+
+  assert.deepEqual(await MetaMask.signAndRecoverPubKey(provider, false, message), {
+    publicKey: expectedPublicKey,
+    signature,
+    message,
+  });
+  assert.deepEqual(calls, [{ address: ACCOUNT, data: message }]);
+});
+
+test("MetaMask EIP-712 signing preserves the production payload and strips only the RPC prefix", async () => {
+  const calls = [];
+  const metamask = createMetaMask();
+  metamask.syncBlockchain = async () => ({ chainId: 9790, blockchain: "Carbon" });
+  metamask.getConnectedAPI = async () => ({
+    request: async (request) => {
+      calls.push(request);
+      return "0x" + "ab".repeat(65);
+    },
+  });
+  const msgs = [{
+    type: "cosmos-sdk/MsgSend",
+    value: {
+      from_address: "swth1sender",
+      to_address: "swth1recipient",
+      amount: [{ denom: "swth", amount: "42" }],
+    },
+  }];
+  const fee = { amount: [{ denom: "swth", amount: "7" }], gas: "90000" };
+
+  const result = await metamask.signEip712(
+    ACCOUNT,
+    "1099511628097",
+    "carbon_9790-1",
+    msgs,
+    fee,
+    "metamask migration vector",
+    "23",
+  );
+
+  assert.equal(result.sig, "ab".repeat(65));
+  assert.deepEqual(result.signedDoc, {
+    account_number: "1099511628097",
+    chain_id: "carbon_9790-1",
+    fee,
+    memo: "metamask migration vector",
+    msgs,
+    sequence: "23",
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "eth_signTypedData_v4");
+  assert.equal(calls[0].params[0], ACCOUNT);
+  const payload = JSON.parse(calls[0].params[1]);
+  assert.equal(payload.primaryType, "Tx");
+  assert.deepEqual(payload.domain, {
+    name: "Carbon",
+    version: "1.0.0",
+    verifyingContract: "0x0000000000000000000000000000636f736D6F73",
+    salt: "1",
+    chainId: "9790",
+  });
+  assert.deepEqual(payload.message, {
+    account_number: "1099511628097",
+    chain_id: "carbon_9790-1",
+    fee,
+    memo: "metamask migration vector",
+    sequence: "23",
+    msg0: msgs[0],
+  });
+});
+
+test("MetaMask EIP-712 cross-chain signing keeps its explicit memo counterexample", async () => {
+  let request;
+  const metamask = createMetaMask();
+  metamask.syncBlockchain = async () => ({ chainId: 1, blockchain: "Ethereum" });
+  metamask.getConnectedAPI = async () => ({
+    request: async (value) => {
+      request = value;
+      return "0x" + "cd".repeat(65);
+    },
+  });
+
+  const result = await metamask.signEip712(
+    ACCOUNT,
+    "7",
+    "carbon_9790-1",
+    [],
+    { amount: [], gas: "1" },
+    "cross-chain",
+    "8",
+  );
+
+  assert.equal(result.signedDoc.memo, "cross-chain|CROSSCHAIN-SIGNING|signed-chain-id:carbon_1-1;carbon-chain-id:carbon_9790-1");
+  assert.equal(JSON.parse(request.params[1]).message.memo, result.signedDoc.memo);
+});
+
+test("MetaMask public declarations do not expose the replaced utility", () => {
+  const declaration = fs.readFileSync(path.join(projectRoot, "lib/provider/metamask/MetaMask.d.ts"), "utf8");
+  assert.doesNotMatch(declaration, /(?:^|["'/])eth-sig-util(?:["'/]|$)/m);
+  assert.match(declaration, /encryptMnemonic\(mnemonic: string\): Promise<string>;/);
+  assert.match(declaration, /decryptCipher\(cipherTextHex\?: string\): Promise<string \| null>;/);
+  assert.match(declaration, /signEip712\([^;]+Promise<\{/s);
+});

--- a/tests/protobuf-utf8-leaf.test.cjs
+++ b/tests/protobuf-utf8-leaf.test.cjs
@@ -86,6 +86,7 @@ test("protobufjs 7.6.3 remains the only audited direct contract", () => {
 
   assert.deepEqual(packageJson.resolutions, {
     "**/@ethersproject/providers/ws": "8.21.0",
+    uuid: "11.1.1",
   });
   assert.deepEqual(versions, ["7.6.3"]);
   assert.deepEqual(protobufOwners(path.join(projectRoot, "node_modules")), []);

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,6 +220,38 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
+"@ethereumjs/common@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-3.2.0.tgz#b71df25845caf5456449163012074a55f048e0a0"
+  integrity sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==
+  dependencies:
+    "@ethereumjs/util" "^8.1.0"
+    crc-32 "^1.2.0"
+
+"@ethereumjs/rlp@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/rlp/-/rlp-4.0.1.tgz#626fabfd9081baab3d0a3074b0c7ecaf674aaa41"
+  integrity sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==
+
+"@ethereumjs/tx@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-4.2.0.tgz#5988ae15daf5a3b3c815493bc6b495e76009e853"
+  integrity sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==
+  dependencies:
+    "@ethereumjs/common" "^3.2.0"
+    "@ethereumjs/rlp" "^4.0.1"
+    "@ethereumjs/util" "^8.1.0"
+    ethereum-cryptography "^2.0.0"
+
+"@ethereumjs/util@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/util/-/util-8.1.0.tgz#299df97fb6b034e0577ce9f94c7d9d1004409ed4"
+  integrity sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==
+  dependencies:
+    "@ethereumjs/rlp" "^4.0.1"
+    ethereum-cryptography "^2.0.0"
+    micro-ftch "^0.3.1"
+
 "@ethersproject/abi@5.8.0", "@ethersproject/abi@^5.8.0":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.8.0.tgz#e79bb51940ac35fe6f3262d7fe2cdb25ad5f07d9"
@@ -728,10 +760,60 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.12.0.tgz#ad903528bf3687a44da435d7b2479d724d374f5d"
   integrity sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA==
 
+"@metamask/abi-utils@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/abi-utils/-/abi-utils-3.0.0.tgz#2eab9cb895922b94305364d9111b6dde724f6f9b"
+  integrity sha512-a/l0DiSIr7+CBYVpHygUa3ztSlYLFCQMsklLna+t6qmNY9+eIO5TedNxhyIyvaJ+4cN7TLy0NQFbp9FV3X2ktg==
+  dependencies:
+    "@metamask/superstruct" "^3.1.0"
+    "@metamask/utils" "^11.0.1"
+
+"@metamask/eth-sig-util@8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-8.2.0.tgz#f114ca5b2a1a997b467933c902e7ec44123eb8fb"
+  integrity sha512-LZDglIh4gYGw9Myp+2aIwKrj6lIJpMC4e0m7wKJU+BxLLBFcrTgKrjdjstXGVWvuYG3kutlh9J+uNBRPJqffWQ==
+  dependencies:
+    "@ethereumjs/rlp" "^4.0.1"
+    "@ethereumjs/util" "^8.1.0"
+    "@metamask/abi-utils" "^3.0.0"
+    "@metamask/utils" "^11.0.1"
+    "@scure/base" "~1.1.3"
+    ethereum-cryptography "^2.1.2"
+    tweetnacl "^1.0.3"
+
+"@metamask/superstruct@^3.1.0":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@metamask/superstruct/-/superstruct-3.4.1.tgz#3374ef336ebc5f9a6c5e3e5d3c28a80c89e8dc28"
+  integrity sha512-caTaaBUcwBGbUNf3r0uT48upX4nECRbKhQ9pPOfW4sIkfcIUUDV4S9DZxq/5fuNPVt5KWpyd5xIIz0sP+iWLlg==
+
+"@metamask/utils@^11.0.1":
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/@metamask/utils/-/utils-11.11.0.tgz#6675946df767da6cbe306c7b5e76685320a6c826"
+  integrity sha512-0nF2CWjWQr/m0Y2t2lJnBTU1/CZPPTvKvcESLplyWe/tyeb8zFOi/FeneDmaFnML6LYRIGZU6f+xR0jKAIUZfw==
+  dependencies:
+    "@ethereumjs/tx" "^4.2.0"
+    "@metamask/superstruct" "^3.1.0"
+    "@noble/hashes" "^1.3.1"
+    "@scure/base" "^1.1.3"
+    "@types/debug" "^4.1.7"
+    "@types/lodash" "^4.17.20"
+    debug "^4.3.4"
+    lodash "^4.17.21"
+    pony-cause "^2.1.10"
+    semver "^7.5.4"
+    uuid "^9.0.1"
+
 "@noble/ciphers@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
   integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
+
+"@noble/curves@1.4.2", "@noble/curves@~1.4.0":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.4.2.tgz#40309198c76ed71bc6dbf7ba24e81ceb4d0d1fe9"
+  integrity sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==
+  dependencies:
+    "@noble/hashes" "1.4.0"
 
 "@noble/curves@1.9.7", "@noble/curves@^1.9.2":
   version "1.9.7"
@@ -740,7 +822,12 @@
   dependencies:
     "@noble/hashes" "1.8.0"
 
-"@noble/hashes@1.8.0", "@noble/hashes@^1.2.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
+"@noble/hashes@1.4.0", "@noble/hashes@~1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
+"@noble/hashes@1.8.0", "@noble/hashes@^1.2.0", "@noble/hashes@^1.3.1", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -818,7 +905,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.2.tgz#78d476333d85d5b1c792e257bca74ba080da49a4"
   integrity sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==
 
-"@scure/base@^1.1.1", "@scure/base@~1.2.5":
+"@scure/base@^1.1.1", "@scure/base@^1.1.3", "@scure/base@~1.2.5":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
   integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
@@ -827,6 +914,28 @@
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-2.2.0.tgz#1311378ed247df6d58f8eb8941921965e97e5747"
   integrity sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==
+
+"@scure/base@~1.1.3", "@scure/base@~1.1.6":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
+
+"@scure/bip32@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.4.0.tgz#4e1f1e196abedcef395b33b9674a042524e20d67"
+  integrity sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==
+  dependencies:
+    "@noble/curves" "~1.4.0"
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
+
+"@scure/bip39@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.3.0.tgz#0f258c16823ddd00739461ac31398b4e7d6a18c3"
+  integrity sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==
+  dependencies:
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
 
 "@scure/bip39@^1.6.0":
   version "1.6.0"
@@ -856,17 +965,17 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
-"@types/bn.js@^4.11.3":
-  version "4.11.6"
-  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
-  integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/crypto-js@4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.0.1.tgz#3a4bd24518b0e6c5940da4e2659eeb2ef0806963"
   integrity sha512-6+OPzqhKX/cx5xh+yO8Cqg3u3alrkhoxhE5ZOdSEv0DOzJ13lwJ6laqGU0Kv6+XDMFmlnGId04LtY22PsFLQUw==
+
+"@types/debug@^4.1.7":
+  version "4.1.13"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.13.tgz#22d1cc9d542d3593caea764f974306ab36286ee7"
+  integrity sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==
+  dependencies:
+    "@types/ms" "*"
 
 "@types/estree@^1.0.6":
   version "1.0.9"
@@ -883,10 +992,20 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.174.tgz#b4b06b6eced9850eed6b6a8f1abdd0f5192803c1"
   integrity sha512-KMBLT6+g9qrGXpDt7ohjWPUD34WA/jasrtjTEHStF0NPdEwJ1N9SZ+4GaMVDeuk/y0+X5j9xFm6mNiXS7UoaLQ==
 
+"@types/lodash@^4.17.20":
+  version "4.17.24"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.24.tgz#4ae334fc62c0e915ca8ed8e35dcc6d4eeb29215f"
+  integrity sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==
+
 "@types/long@4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
+"@types/ms@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
+  integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
 "@types/node-fetch@^2.5.12":
   version "2.5.12"
@@ -918,24 +1037,10 @@
   dependencies:
     undici-types "~7.18.0"
 
-"@types/pbkdf2@^3.0.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@types/pbkdf2/-/pbkdf2-3.1.0.tgz#039a0e9b67da0cdc4ee5dab865caa6b267bb66b1"
-  integrity sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/ripemd160@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/ripemd160/-/ripemd160-2.0.0.tgz#d33e49cf66edf4668828030d4aa80116bbf8ae81"
   integrity sha512-LD6AO/+8cAa1ghXax9NG9iPDLPUEGB2WWPjd//04KYfXxTwHvlDEfL0NRjrM5z9XWBi6WbKw75Are0rDyn3PSA==
-  dependencies:
-    "@types/node" "*"
-
-"@types/secp256k1@^4.0.1":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@types/secp256k1/-/secp256k1-4.0.3.tgz#1b8e55d8e00f08ee7220b4d59a6abe89c37a901c"
-  integrity sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==
   dependencies:
     "@types/node" "*"
 
@@ -1217,17 +1322,12 @@ bip39@^3.0.4:
     pbkdf2 "^3.0.9"
     randombytes "^2.0.1"
 
-blakejs@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.1.tgz#bf313053978b2cd4c444a48795710be05c785702"
-  integrity sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==
-
-bn.js@^4.11.0, bn.js@^4.11.8, bn.js@^4.11.9:
+bn.js@^4.11.9:
   version "4.12.3"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.3.tgz#2cc2c679188eb35b006f2d0d4710bed8437a769e"
   integrity sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==
 
-bn.js@^5.2.0, bn.js@^5.2.1:
+bn.js@^5.2.1:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.3.tgz#16a9e409616b23fef3ccbedb8d42f13bff80295e"
   integrity sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==
@@ -1264,18 +1364,6 @@ browser-headers@^0.4.1:
   resolved "https://registry.yarnpkg.com/browser-headers/-/browser-headers-0.4.1.tgz#4308a7ad3b240f4203dbb45acedb38dc2d65dd02"
   integrity sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg==
 
-browserify-aes@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
-  integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
-  dependencies:
-    buffer-xor "^1.0.3"
-    cipher-base "^1.0.0"
-    create-hash "^1.1.0"
-    evp_bytestokey "^1.0.3"
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
-
 bs58@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
@@ -1290,7 +1378,7 @@ bs58@^6.0.0:
   dependencies:
     base-x "^5.0.0"
 
-bs58check@<3.0.0, bs58check@^2.1.2:
+bs58check@<3.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
   integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
@@ -1306,11 +1394,6 @@ bs58check@^4.0.0:
   dependencies:
     "@noble/hashes" "^1.2.0"
     bs58 "^6.0.0"
-
-buffer-xor@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
-  integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -1366,7 +1449,7 @@ chokidar@^3.5.2, chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
+cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.5.tgz#749f80731c7821e9a5fabd51f6998b696f296686"
   integrity sha512-xq7ICKB4TMHUx7Tz1L9O2SGKOhYMOTR32oir45Bq28/AQTpHogKgHcoYFSdRbMtddl+ozNXfXY9jWcgYKmde0w==
@@ -1408,7 +1491,12 @@ cosmjs-types@0.11.0, cosmjs-types@^0.11.0:
   resolved "https://registry.yarnpkg.com/cosmjs-types/-/cosmjs-types-0.11.0.tgz#e13c495e522acc08d6a8c63b925d746d23d38710"
   integrity sha512-kDSkgHpRTrg1413jCNehT3P21+EBxZWFMBr9JEzVfmPiNdtuwAoLAkCYo7c7i/pTakAwyHsXbxOg8kkD+AN33w==
 
-create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
+crc-32@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
+  integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
+
+create-hash@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
   integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
@@ -1465,7 +1553,7 @@ dayjs@^1.10.5:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
   integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
 
-debug@^4, debug@^4.3.1, debug@^4.4.3:
+debug@^4, debug@^4.3.1, debug@^4.3.4, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -1536,7 +1624,7 @@ dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
-elliptic@6.6.1, elliptic@^6.5.2, elliptic@^6.5.7:
+elliptic@6.6.1:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
   integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
@@ -1677,70 +1765,15 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-eth-sig-util@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-3.0.1.tgz#8753297c83a3f58346bd13547b59c4b2cd110c96"
-  integrity sha512-0Us50HiGGvZgjtWTyAI/+qTzYPMLy5Q451D0Xy68bxq1QMWdoOddDwGvsqcFT27uohKgalM9z/yxplyt+mY2iQ==
+ethereum-cryptography@^2.0.0, ethereum-cryptography@^2.1.2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz#58f2810f8e020aecb97de8c8c76147600b0b8ccf"
+  integrity sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==
   dependencies:
-    ethereumjs-abi "^0.6.8"
-    ethereumjs-util "^5.1.1"
-    tweetnacl "^1.0.3"
-    tweetnacl-util "^0.15.0"
-
-ethereum-cryptography@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz#8d6143cfc3d74bf79bbd8edecdf29e4ae20dd191"
-  integrity sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==
-  dependencies:
-    "@types/pbkdf2" "^3.0.0"
-    "@types/secp256k1" "^4.0.1"
-    blakejs "^1.1.0"
-    browserify-aes "^1.2.0"
-    bs58check "^2.1.2"
-    create-hash "^1.2.0"
-    create-hmac "^1.1.7"
-    hash.js "^1.1.7"
-    keccak "^3.0.0"
-    pbkdf2 "^3.0.17"
-    randombytes "^2.1.0"
-    safe-buffer "^5.1.2"
-    scrypt-js "^3.0.0"
-    secp256k1 "^4.0.1"
-    setimmediate "^1.0.5"
-
-ethereumjs-abi@^0.6.8:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz#71bc152db099f70e62f108b7cdfca1b362c6fcae"
-  integrity sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==
-  dependencies:
-    bn.js "^4.11.8"
-    ethereumjs-util "^6.0.0"
-
-ethereumjs-util@^5.1.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz#a833f0e5fca7e5b361384dc76301a721f537bf65"
-  integrity sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==
-  dependencies:
-    bn.js "^4.11.0"
-    create-hash "^1.1.2"
-    elliptic "^6.5.2"
-    ethereum-cryptography "^0.1.3"
-    ethjs-util "^0.1.3"
-    rlp "^2.0.0"
-    safe-buffer "^5.1.1"
-
-ethereumjs-util@^6.0.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz#fcb4e4dd5ceacb9d2305426ab1a5cd93e3163b69"
-  integrity sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==
-  dependencies:
-    "@types/bn.js" "^4.11.3"
-    bn.js "^4.11.0"
-    create-hash "^1.1.2"
-    elliptic "^6.5.2"
-    ethereum-cryptography "^0.1.3"
-    ethjs-util "0.1.6"
-    rlp "^2.2.3"
+    "@noble/curves" "1.4.2"
+    "@noble/hashes" "1.4.0"
+    "@scure/bip32" "1.4.0"
+    "@scure/bip39" "1.3.0"
 
 ethers@5.8.0:
   version "5.8.0"
@@ -1778,26 +1811,10 @@ ethers@5.8.0:
     "@ethersproject/web" "5.8.0"
     "@ethersproject/wordlists" "5.8.0"
 
-ethjs-util@0.1.6, ethjs-util@^0.1.3:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
-  integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
-  dependencies:
-    is-hex-prefixed "1.0.0"
-    strip-hex-prefix "1.0.0"
-
 events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
-
-evp_bytestokey@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
-  integrity sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
-  dependencies:
-    md5.js "^1.3.4"
-    safe-buffer "^5.1.1"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -2050,7 +2067,7 @@ hash-wasm@^4.12.0:
   resolved "https://registry.yarnpkg.com/hash-wasm/-/hash-wasm-4.12.0.tgz#f9f1a9f9121e027a9acbf6db5d59452ace1ef9bb"
   integrity sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==
 
-hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -2138,11 +2155,6 @@ is-glob@^4.0.3:
   dependencies:
     is-extglob "^2.1.1"
 
-is-hex-prefixed@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
-  integrity sha1-fY035q135dEnFIkTxXPggtd39VQ=
-
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -2202,15 +2214,6 @@ jwt-decode@^4.0.0:
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
   integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
 
-keccak@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.2.tgz#4c2c6e8c54e04f2670ee49fa734eb9da152206e0"
-  integrity sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==
-  dependencies:
-    node-addon-api "^2.0.0"
-    node-gyp-build "^4.2.0"
-    readable-stream "^3.6.0"
-
 keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -2248,7 +2251,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4.18.1:
+lodash@4.18.1, lodash@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
@@ -2286,6 +2289,11 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micro-ftch@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/micro-ftch/-/micro-ftch-0.3.1.tgz#6cb83388de4c1f279a034fb0cf96dfc050853c5f"
+  integrity sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==
 
 micromatch@^4.0.4:
   version "4.0.8"
@@ -2351,27 +2359,12 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-node-addon-api@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
-  integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
-
-node-addon-api@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
-  integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
-
 node-fetch@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-gyp-build@^4.2.0:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
-  integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
 nodemon@^3.1.14:
   version "3.1.14"
@@ -2447,7 +2440,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pbkdf2@^3.0.17, pbkdf2@^3.0.9:
+pbkdf2@^3.0.9:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.3.tgz#8be674d591d65658113424592a95d1517318dd4b"
   integrity sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==
@@ -2475,6 +2468,11 @@ plimit-lit@^1.2.6:
   integrity sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==
   dependencies:
     queue-lit "^1.5.1"
+
+pony-cause@^2.1.10:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/pony-cause/-/pony-cause-2.1.11.tgz#d69a20aaccdb3bdb8f74dd59e5c68d8e6772e4bd"
+  integrity sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
@@ -2544,7 +2542,7 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-randombytes@^2.0.1, randombytes@^2.1.0:
+randombytes@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -2608,13 +2606,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1, ripemd160@^2.0.2:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rlp@^2.0.0, rlp@^2.2.3:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.7.tgz#33f31c4afac81124ac4b283e2bd4d9720b30beaf"
-  integrity sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==
-  dependencies:
-    bn.js "^5.2.0"
-
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -2636,26 +2627,17 @@ rxjs@^7.8.1:
   dependencies:
     tslib "^2.1.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-scrypt-js@3.0.1, scrypt-js@^3.0.0:
+scrypt-js@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
 
-secp256k1@^4.0.1:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.4.tgz#58f0bfe1830fe777d9ca1ffc7574962a8189f8ab"
-  integrity sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==
-  dependencies:
-    elliptic "^6.5.7"
-    node-addon-api "^5.0.0"
-    node-gyp-build "^4.2.0"
-
-semver@7.8.5, semver@^7.3.5, semver@^7.5.3, semver@^7.7.3:
+semver@7.8.5, semver@^7.3.5, semver@^7.5.3, semver@^7.5.4, semver@^7.7.3:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
@@ -2671,11 +2653,6 @@ set-function-length@^1.2.2:
     get-intrinsic "^1.2.4"
     gopd "^1.0.1"
     has-property-descriptors "^1.0.2"
-
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8:
   version "2.4.12"
@@ -2726,13 +2703,6 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
-
-strip-hex-prefix@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz#0c5f155fef1151373377de9dbb588da05500e36f"
-  integrity sha1-DF8VX+8RUTczd96du1iNoFUA428=
-  dependencies:
-    is-hex-prefixed "1.0.0"
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -2839,11 +2809,6 @@ tslib@^2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
-tweetnacl-util@^0.15.0:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
-  integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
-
 tweetnacl@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
@@ -2906,6 +2871,11 @@ util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+uuid@11.1.1, uuid@^9.0.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
## Summary
- replace deprecated `eth-sig-util@3.0.1` with maintained `@metamask/eth-sig-util@8.2.0`
- remove both legacy `ethereumjs-util` Elliptic owner paths
- preserve personal signing, public-key recovery, EIP-712, cross-chain memo handling, encryption, and decryption behavior
- retain compatibility with a fixed ciphertext generated by the legacy v3 package
- enforce and document the necessary application-root `uuid@11.1.1` override

## Stack
- based on `deps/modernize-secp256k1-stack`
- Ethers remains pinned to 5.8.0 and is not changed

## Validation
- Node 24.18.0 / Yarn 1.22.22
- focused MetaMask, secp, wallet, UUID, declaration, and owner contracts pass
- ESLint passes
- final stacked Carbon suite: 141/141
- packed npm consumer and Disco app gates pass
