### PR TITLE
deps: align Keplr types with Starknet 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@ethersproject/abstract-signer": "5.8.0",
     "@improbable-eng/grpc-web": "^0.15.0",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
-    "@keplr-wallet/types": "^0.12.207",
+    "@keplr-wallet/types": "^0.13.40",
     "@ledgerhq/hw-transport": "6.28.8",
     "@ledgerhq/hw-transport-webhid": "^6.20.0",
     "@metamask/eth-sig-util": "8.2.0",

--- a/tests/cosmos-wallet-contracts.test.cjs
+++ b/tests/cosmos-wallet-contracts.test.cjs
@@ -8,7 +8,7 @@ const { spawnSync } = require("node:child_process");
 const Long = require("long");
 
 const projectRoot = path.resolve(__dirname, "..");
-const { LeapAccount } = require(path.join(projectRoot, "lib/index.js"));
+const { KeplrAccount, LeapAccount } = require(path.join(projectRoot, "lib/index.js"));
 
 function signature(value) {
   return {
@@ -30,6 +30,23 @@ function fakeLeap(calls) {
         isNanoLedger: false,
       };
     },
+    async signDirect(chainId, address, doc, options) {
+      calls.push(["signDirect", chainId, address, doc, options]);
+      return { signed: doc, signature: signature("direct") };
+    },
+    async signAmino(chainId, address, doc, options) {
+      calls.push(["signAmino", chainId, address, doc, options]);
+      return { signed: doc, signature: signature("amino") };
+    },
+    async signArbitrary(chainId, address, message) {
+      calls.push(["signArbitrary", chainId, address, message]);
+      return signature("arbitrary");
+    },
+  };
+}
+
+function fakeKeplr(calls) {
+  return {
     async signDirect(chainId, address, doc, options) {
       calls.push(["signDirect", chainId, address, doc, options]);
       return { signed: doc, signature: signature("direct") };
@@ -106,6 +123,59 @@ test("Leap signer preserves account, direct, amino, and arbitrary-signing contra
   await signer.signAmino("swth1contract", aminoDoc);
   const aminoCall = calls.find(([name]) => name === "signAmino");
   assert.deepEqual(aminoCall.slice(1), ["carbon-1", "swth1contract", aminoDoc, { preferNoSetFee: true }]);
+
+  assert.equal(await signer.signMessage("swth1contract", "Carbon compatibility"), Buffer.from("arbitrary").toString("hex"));
+  assert.deepEqual(calls.find(([name]) => name === "signArbitrary").slice(1), [
+    "carbon-1",
+    "swth1contract",
+    "Carbon compatibility",
+  ]);
+});
+
+test("Keplr 0.13 signer preserves account, direct, amino, and arbitrary-signing contracts", async () => {
+  const calls = [];
+  const chainInfo = { chainId: "carbon-1" };
+  const account = {
+    name: "Carbon account",
+    algo: "secp256k1",
+    pubKey: Uint8Array.from([2, 3, 4]),
+    address: Uint8Array.from([5, 6, 7]),
+    bech32Address: "swth1contract",
+    isNanoLedger: false,
+  };
+  const signer = KeplrAccount.createKeplrSigner(fakeKeplr(calls), chainInfo, account);
+
+  assert.deepEqual(await signer.getAccounts(), [
+    {
+      algo: "secp256k1",
+      address: "swth1contract",
+      pubkey: Uint8Array.from([2, 3, 4]),
+    },
+  ]);
+
+  const bodyBytes = Uint8Array.from([1, 2]);
+  const authInfoBytes = Uint8Array.from([3, 4]);
+  const directDoc = { bodyBytes, authInfoBytes, chainId: "carbon-1", accountNumber: 7n };
+  await signer.signDirect("swth1contract", directDoc);
+
+  const directCall = calls.find(([name]) => name === "signDirect");
+  assert.equal(directCall[1], "carbon-1");
+  assert.equal(directCall[2], "swth1contract");
+  assert.equal(Long.isLong(directCall[3].accountNumber), true);
+  assert.equal(directCall[3].accountNumber.toString(), "7");
+  assert.deepEqual(directCall[3].bodyBytes, bodyBytes);
+  assert.deepEqual(directCall[3].authInfoBytes, authInfoBytes);
+  assert.equal(directCall[3].chainId, "carbon-1");
+  assert.deepEqual(directCall[4], { preferNoSetFee: true });
+
+  const aminoDoc = { chain_id: "carbon-1", account_number: "7", sequence: "2", fee: {}, msgs: [], memo: "" };
+  await signer.signAmino("swth1contract", aminoDoc);
+  assert.deepEqual(calls.find(([name]) => name === "signAmino").slice(1), [
+    "carbon-1",
+    "swth1contract",
+    aminoDoc,
+    { preferNoSetFee: true },
+  ]);
 
   assert.equal(await signer.signMessage("swth1contract", "Carbon compatibility"), Buffer.from("arbitrary").toString("hex"));
   assert.deepEqual(calls.find(([name]) => name === "signArbitrary").slice(1), [

--- a/tests/fixtures/keplr-013-public-types.ts
+++ b/tests/fixtures/keplr-013-public-types.ts
@@ -1,0 +1,11 @@
+import type { Keplr } from "../../lib";
+
+declare const keplr: Keplr;
+
+void keplr.signDirectWithMessages("carbon-1", "swth1contract", [], {
+  memo: "Carbon compatibility",
+  sync: true,
+});
+void keplr.signFigureMarketsAuth("carbon-1", "swth1contract", "Carbon compatibility");
+void keplr.getAllWallets();
+void keplr.switchAccount("wallet-id");

--- a/tests/keplr-013-compatibility.test.cjs
+++ b/tests/keplr-013-compatibility.test.cjs
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global __dirname, process, require */
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const { spawnSync } = require("node:child_process");
+
+const projectRoot = path.resolve(__dirname, "..");
+const manifest = require(path.join(projectRoot, "package.json"));
+const lockfile = fs.readFileSync(path.join(projectRoot, "yarn.lock"), "utf8");
+const installedManifest = require(path.join(projectRoot, "node_modules/@keplr-wallet/types/package.json"));
+
+function lockedVersions(packageName) {
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const stanza = new RegExp(`^"${escaped}@[^"]+":\\n(?:[ ]{2}[^\\n]*\\n|[ ]{4}[^\\n]*\\n)*`, "gm");
+  return [...lockfile.matchAll(stanza)]
+    .map((match) => match[0].match(/^[ ]{2}version "([^"]+)"$/m)?.[1])
+    .filter(Boolean)
+    .sort();
+}
+
+test("Carbon aligns its public Keplr types with the Starknet 8 wallet family", () => {
+  assert.equal(manifest.dependencies["@keplr-wallet/types"], "^0.13.40");
+  assert.equal(installedManifest.version, "0.13.40");
+  assert.deepEqual(installedManifest.peerDependencies, { starknet: "^8" });
+  assert.deepEqual(lockedVersions("@keplr-wallet/types"), ["0.13.40"]);
+  assert.doesNotMatch(lockfile, /@keplr-wallet\/types@\^0\.12/);
+});
+
+test("Carbon exports the Keplr 0.13 wallet surface", () => {
+  const tsc = require.resolve("typescript/bin/tsc");
+  const fixture = path.join(projectRoot, "tests/fixtures/keplr-013-public-types.ts");
+  const result = spawnSync(
+    process.execPath,
+    [tsc, "--noEmit", "--strict", "--skipLibCheck", "--esModuleInterop", "--module", "commonjs", "--moduleResolution", "node", "--target", "es2020", fixture],
+    { cwd: projectRoot, encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,10 +655,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@keplr-wallet/types@^0.12.207":
-  version "0.12.207"
-  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.207.tgz#50865c51dec7c12c063e73c23f7620b40c304072"
-  integrity sha512-GatUZEXTqOp3K5U7BjG+fqs/+AXZqa3mp/ug1vZstRwdNgGxel/eJBAp9CsBV3J30HwCzFOARO/XPTR5vDXAIA==
+"@keplr-wallet/types@^0.13.40":
+  version "0.13.40"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.13.40.tgz#248af8c0a6f4bbcfef6d0372c9022b321bbdd4d8"
+  integrity sha512-JGeUMjtjcO3PCL8mroWVYbIc+sR4y/yuvxXb2FBlTarkER9AzEbMZJE8NSFhPBKoZD6UHBUXn+xIrc17tPqaSQ==
   dependencies:
     long "^4.0.0"
 


### PR DESCRIPTION
## What changed

- Updates `@keplr-wallet/types` from `^0.12.207` to `^0.13.40`, aligning Carbon's public Keplr type dependency with the Starknet 8 peer family used by current Keplr releases.
- Adds a lock and installed-package contract that rejects the old Keplr 0.12/Starknet 6 boundary.
- Adds public type coverage for the Keplr 0.13 wallet surface.
- Characterizes Carbon's Keplr account, direct-signing, Amino-signing, sign-options, and arbitrary-message behavior.

## Why

Carbon 0.11.75 currently resolves `@keplr-wallet/types@0.12.x`, whose `starknet@^6` peer conflicts with applications using Keplr 0.13.x and Starknet 8. Updating the consuming application alone leaves both Keplr type families and their incompatible Starknet peers in the graph.

This changes Carbon's direct owner to the current Keplr 0.13/Starknet 8 family without adding Starknet as a Carbon runtime dependency or relying on a consumer-only resolution.

## Compatibility

Carbon publicly re-exports Keplr's `Keplr` and `ChainInfo` types. Keplr 0.13 adds required wallet methods, so this should ship with the next compatibility-breaking Carbon release rather than being represented as an isolated patch-level public-type change.

## Validation

- [x] Node 24.18.0
- [x] RED contract reproduced against Keplr types 0.12.207
- [x] lifecycle-disabled install and matching Yarn integrity check
- [x] lifecycle-enabled forced install and matching Yarn integrity check
- [x] `yarn build`
- [x] full suite: **144/144 passed**
- [x] dependency hygiene: **47/47 passed**
- [x] focused Keplr/Cosmos wallet contracts: **6/6 passed**
- [x] `npm pack --dry-run`
- [x] `git diff --check`
- [x] app-like packed consumer resolved `@keplr-wallet/provider-extension@0.13.40`, `@keplr-wallet/types@0.13.40`, and `starknet@8.9.2`
- [x] packed consumer had no Keplr 0.12 owner and no Keplr/Starknet peer warning
- [x] packed consumer application typecheck passed with `skipLibCheck`; strict dependency checking remains blocked by the pre-existing missing packed `provider/keplr/window.d.ts` and `@types/ws` declaration closure

## Supply chain

- Apache-2.0 license and sole `long@^4.0.0` dependency are unchanged.
- No install, preinstall, or postinstall hooks are introduced.
- Registry signature and npm publish/SLSA provenance attestations are present.
- Provenance resolves to `chainapsis/keplr-wallet` tag `v0.13.40`, commit `4efcc22fbfa8c77c516c06344ac2345760a95154`.
- Registry SHA-512 integrity and SHA-1 tarball identifiers match the regenerated lockfile.
- Lockfile movement is limited to the single `@keplr-wallet/types` artifact.
