### PR TITLE
fix: use supported GitHub Actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,9 +46,6 @@ updates:
       timezone: "Asia/Singapore"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
     open-pull-requests-limit: 2
     labels:
       - "dependencies"


### PR DESCRIPTION
## What changed

- Remove `semver-major-days`, `semver-minor-days`, and `semver-patch-days` only from the `github-actions` Dependabot cooldown because GitHub rejects those fields for that ecosystem.
- Keep `default-days: 7` for GitHub Actions so the intended low-noise cooldown remains active.
- Preserve the npm ecosystem's semver-specific cooldowns, which GitHub supports for npm/Yarn.

## Root cause

The GitHub Actions entry copied semver-specific cooldown fields from the npm entry in #627. YAML syntax remained valid, so the Node 24 workflow passed while GitHub's ecosystem-aware Dependabot parser rejected the configuration.

## Validation

- [x] PyYAML parses the file as Dependabot v2 with two update entries.
- [x] The GitHub Actions cooldown resolves exactly to `{ default-days: 7 }`.
- [x] The npm semver cooldown policy remains unchanged.
- [x] GitHub's current Dependabot support matrix lists default cooldown days as supported and SemVer-bump days as unsupported for GitHub Actions.
- [x] `git diff --check` passes.
- [x] Node 24 CI passes on exact commit `2e94370cf5ba1081b59c2a0d88fc7a58e5056588` ([run 29714073316](https://github.com/Switcheo/carbon-js-sdk/actions/runs/29714073316)).

GitHub did not emit the dedicated `Dependabot / .github/dependabot.yml` check on the pull-request head. The correction therefore follows both the parser's exact rejected-property diagnostics and GitHub's documented ecosystem support matrix.