### PR TITLE
Promote Dependabot config fix to master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,9 +46,6 @@ updates:
       timezone: "Asia/Singapore"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
     open-pull-requests-limit: 2
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary

Promote the validated Dependabot cooldown correction from `staging` at `ec0c5a9b27f09f8f75318b31bfc4c2d3ddf99587` to `master`.

## Exact change

- Remove the unsupported `semver-major-days`, `semver-minor-days`, and `semver-patch-days` fields from the `github-actions` cooldown.
- Preserve `default-days: 7` for GitHub Actions and preserve npm's supported SemVer-specific cooldowns.

GitHub's compare reports one changed file and three deletions relative to the current master tip `11ee8fcdbf7d36d363e34bfe6fff3c296a8d0cc4`.

## Staging verification

- Dependabot config parser: passed
- GitHub Actions Dependabot update: passed
- npm/Yarn Dependabot update: passed
- Node 24: passed ([run 29714913800](https://github.com/Switcheo/carbon-js-sdk/actions/runs/29714913800))

## Promotion behavior

This PR changes GitHub branch state only. The repository has no publish/deploy workflow. A merge commit preserves the staging promotion history. The Node 24 workflow excludes `master`, so post-merge verification will use the dedicated Dependabot config check and exact tree/diff readback.