### PR TITLE
ci: publish prebuilt release packages

### DIFF
--- a/.github/scripts/publish-release-package.sh
+++ b/.github/scripts/publish-release-package.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GH_REPO:?GH_REPO is required}"
+: "${RELEASE_TAG:?RELEASE_TAG is required}"
+: "${RELEASE_VERSION:?RELEASE_VERSION is required}"
+: "${RELEASE_COMMIT:?RELEASE_COMMIT is required}"
+: "${RELEASE_PRERELEASE:?RELEASE_PRERELEASE is required}"
+: "${RELEASE_ARTIFACT:?RELEASE_ARTIFACT is required}"
+: "${RELEASE_CHECKSUM:?RELEASE_CHECKSUM is required}"
+: "${RELEASE_DIGEST:?RELEASE_DIGEST is required}"
+
+if [[ "$RELEASE_TAG" != "v${RELEASE_VERSION}" ]]; then
+  echo "Release tag $RELEASE_TAG does not match version $RELEASE_VERSION" >&2
+  exit 1
+fi
+if [[ "$RELEASE_PRERELEASE" != "true" && "$RELEASE_PRERELEASE" != "false" ]]; then
+  echo "RELEASE_PRERELEASE must be true or false" >&2
+  exit 1
+fi
+
+verify_local_inputs() {
+  local actual_digest expected_checksum_name
+  for file in "$RELEASE_ARTIFACT" "$RELEASE_CHECKSUM"; do
+    if [[ ! -f "$file" ]]; then
+      echo "Release asset does not exist: $file" >&2
+      exit 1
+    fi
+  done
+
+  actual_digest="$(sha256sum "$RELEASE_ARTIFACT" | cut -d' ' -f1)"
+  if [[ "$actual_digest" != "$RELEASE_DIGEST" ]]; then
+    echo "Artifact digest changed before upload: expected $RELEASE_DIGEST, got $actual_digest" >&2
+    exit 1
+  fi
+
+  expected_checksum_name="$(basename "$RELEASE_ARTIFACT").sha256"
+  if [[ "$(basename "$RELEASE_CHECKSUM")" != "$expected_checksum_name" ]]; then
+    echo "Checksum asset must be named $expected_checksum_name" >&2
+    exit 1
+  fi
+  if ! cmp -s "$RELEASE_CHECKSUM" <(printf '%s  %s\n' "$RELEASE_DIGEST" "$(basename "$RELEASE_ARTIFACT")"); then
+    echo "Checksum file does not contain the expected digest and artifact name" >&2
+    exit 1
+  fi
+}
+
+resolve_remote_tag_commit() {
+  local object object_type object_sha depth
+  object="$(gh api "repos/${GH_REPO}/git/ref/tags/${RELEASE_TAG}" --jq '.object.type + " " + .object.sha')"
+  read -r object_type object_sha <<< "$object"
+  for ((depth = 0; depth < 8; depth++)); do
+    if [[ "$object_type" == "commit" && "$object_sha" =~ ^[0-9a-f]{40}$ ]]; then
+      printf '%s\n' "$object_sha"
+      return 0
+    fi
+    if [[ "$object_type" != "tag" || ! "$object_sha" =~ ^[0-9a-f]{40}$ ]]; then
+      echo "Remote tag $RELEASE_TAG resolved to invalid object: $object_type $object_sha" >&2
+      return 1
+    fi
+    object="$(gh api "repos/${GH_REPO}/git/tags/${object_sha}" --jq '.object.type + " " + .object.sha')"
+    read -r object_type object_sha <<< "$object"
+  done
+  echo "Remote tag $RELEASE_TAG exceeded the annotated-tag resolution limit" >&2
+  return 1
+}
+
+verify_remote_tag() {
+  local remote_commit
+  remote_commit="$(resolve_remote_tag_commit)"
+  if [[ "$remote_commit" != "$RELEASE_COMMIT" ]]; then
+    echo "Remote tag $RELEASE_TAG does not resolve to tagged commit $RELEASE_COMMIT; got $remote_commit" >&2
+    exit 1
+  fi
+}
+
+verify_local_inputs
+verify_remote_tag
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+provenance_file="$workdir/provenance.md"
+cat > "$provenance_file" <<EOF
+<!-- carbon-js-sdk-prebuilt-provenance -->
+## Prebuilt package provenance
+
+- Tagged commit: \`$RELEASE_COMMIT\`
+- Artifact SHA-256: \`$RELEASE_DIGEST\`
+<!-- /carbon-js-sdk-prebuilt-provenance -->
+EOF
+
+release_endpoint="repos/${GH_REPO}/releases/tags/${RELEASE_TAG}"
+release_state="$workdir/release.json"
+release_probe_error="$workdir/release-probe-error.txt"
+set +e
+release_probe="$(gh api --silent --include "$release_endpoint" 2>"$release_probe_error")"
+release_probe_status=$?
+set -e
+release_status_line="${release_probe%%$'\n'*}"
+if [[ "$release_status_line" =~ ^HTTP/[0-9.]+[[:space:]]+([0-9]{3}) ]]; then
+  release_http_status="${BASH_REMATCH[1]}"
+else
+  echo "Unable to determine GitHub Release state for $RELEASE_TAG: missing HTTP status" >&2
+  sed 's/^/gh: /' "$release_probe_error" >&2
+  exit 1
+fi
+
+release_exists=false
+case "$release_http_status" in
+  200)
+    if (( release_probe_status != 0 )); then
+      echo "Unable to determine GitHub Release state for $RELEASE_TAG: HTTP 200 returned with a failed request" >&2
+      sed 's/^/gh: /' "$release_probe_error" >&2
+      exit 1
+    fi
+    gh api "$release_endpoint" > "$release_state"
+    RELEASE_JSON_FILE="$release_state" node <<'NODE'
+    const fs = require("node:fs");
+    const release = JSON.parse(fs.readFileSync(process.env.RELEASE_JSON_FILE, "utf8"));
+    if (!Array.isArray(release.assets) || !release.assets.every(asset => typeof asset?.name === "string")) {
+      throw new Error("GitHub Release assets response is malformed");
+    }
+    if (release.body !== null && typeof release.body !== "string") {
+      throw new Error("GitHub Release body response is malformed");
+    }
+    if (typeof release.prerelease !== "boolean") {
+      throw new Error("GitHub Release prerelease response is malformed");
+    }
+NODE
+    release_exists=true
+    ;;
+  404)
+    if (( release_probe_status == 0 )); then
+      echo "Unable to determine GitHub Release state for $RELEASE_TAG: HTTP 404 returned as success" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Unable to determine GitHub Release state for $RELEASE_TAG: HTTP $release_http_status" >&2
+    sed 's/^/gh: /' "$release_probe_error" >&2
+    exit 1
+    ;;
+esac
+
+missing_assets=()
+release_has_asset() {
+  RELEASE_JSON_FILE="$release_state" ASSET_NAME="$1" node <<'NODE'
+  const fs = require("node:fs");
+  const release = JSON.parse(fs.readFileSync(process.env.RELEASE_JSON_FILE, "utf8"));
+  process.exit(release.assets.some(asset => asset.name === process.env.ASSET_NAME) ? 0 : 1);
+NODE
+}
+
+verify_existing_asset() {
+  local file="$1"
+  local name remote_file local_digest remote_digest
+  name="$(basename "$file")"
+  if release_has_asset "$name"; then
+    remote_file="$workdir/$name"
+    rm -f "$remote_file"
+    gh release download "$RELEASE_TAG" --repo "$GH_REPO" --pattern "$name" --dir "$workdir"
+    local_digest="$(sha256sum "$file" | cut -d' ' -f1)"
+    remote_digest="$(sha256sum "$remote_file" | cut -d' ' -f1)"
+    if [[ "$local_digest" != "$remote_digest" ]]; then
+      echo "Refusing to replace existing release asset $name: local SHA-256 $local_digest differs from remote $remote_digest" >&2
+      exit 1
+    fi
+    echo "Existing release asset $name has identical bytes; leaving it unchanged."
+  else
+    missing_assets+=("$file")
+  fi
+}
+
+current_prerelease="$RELEASE_PRERELEASE"
+if [[ "$release_exists" == true ]]; then
+  verify_existing_asset "$RELEASE_ARTIFACT"
+  verify_existing_asset "$RELEASE_CHECKSUM"
+
+  current_notes="$workdir/current-notes.md"
+  RELEASE_JSON_FILE="$release_state" NOTES_FILE="$current_notes" node <<'NODE'
+  const fs = require("node:fs");
+  const release = JSON.parse(fs.readFileSync(process.env.RELEASE_JSON_FILE, "utf8"));
+  fs.writeFileSync(process.env.NOTES_FILE, release.body ?? "");
+NODE
+  NOTES_FILE="$current_notes" PROVENANCE_FILE="$provenance_file" node <<'NODE'
+  const fs = require("node:fs");
+  const body = fs.readFileSync(process.env.NOTES_FILE, "utf8").trimEnd();
+  const provenance = fs.readFileSync(process.env.PROVENANCE_FILE, "utf8").trimEnd();
+  const start = "<!-- carbon-js-sdk-prebuilt-provenance -->";
+  const end = "<!-- /carbon-js-sdk-prebuilt-provenance -->";
+  const count = (text, marker) => text.split(marker).length - 1;
+  const starts = count(body, start);
+  const ends = count(body, end);
+  if (starts === 0 && ends === 0) process.exit(0);
+  if (starts !== 1 || ends !== 1) {
+    throw new Error("Release notes must contain exactly one complete prebuilt-package provenance block");
+  }
+  const startIndex = body.indexOf(start);
+  const endIndex = body.indexOf(end);
+  if (startIndex > endIndex) {
+    throw new Error("Release notes contain a malformed prebuilt-package provenance block");
+  }
+  const existing = body.slice(startIndex, endIndex + end.length);
+  if (existing !== provenance) {
+    throw new Error("Release notes already contain different prebuilt-package provenance");
+  }
+NODE
+  current_prerelease="$(RELEASE_JSON_FILE="$release_state" node -e 'const fs=require("node:fs"); process.stdout.write(String(JSON.parse(fs.readFileSync(process.env.RELEASE_JSON_FILE, "utf8")).prerelease))')"
+else
+  verify_remote_tag
+  create_args=(
+    "$RELEASE_TAG"
+    --repo "$GH_REPO"
+    --verify-tag
+    --target "$RELEASE_COMMIT"
+    --title "$RELEASE_TAG"
+    --generate-notes
+    --notes-file "$provenance_file"
+  )
+  if [[ "$RELEASE_PRERELEASE" == true ]]; then
+    create_args+=(--prerelease)
+  fi
+  gh release create "${create_args[@]}"
+  missing_assets=("$RELEASE_ARTIFACT" "$RELEASE_CHECKSUM")
+fi
+
+if (( ${#missing_assets[@]} > 0 )); then
+  verify_local_inputs
+  verify_remote_tag
+  gh release upload "$RELEASE_TAG" --repo "$GH_REPO" "${missing_assets[@]}"
+fi
+
+if [[ "$current_prerelease" != "$RELEASE_PRERELEASE" ]]; then
+  verify_remote_tag
+  gh release edit "$RELEASE_TAG" --repo "$GH_REPO" --prerelease="$RELEASE_PRERELEASE"
+fi
+
+verify_remote_tag

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -47,9 +47,9 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
       commit: ${{ steps.release.outputs.commit }}
-      artifact-name: ${{ steps.package.outputs.artifact-name }}
-      artifact-path: ${{ steps.package.outputs.artifact-path }}
-      checksum-path: ${{ steps.package.outputs.checksum-path }}
+      artifact-name: ${{ steps.package.outputs['artifact-name'] }}
+      artifact-path: ${{ steps.package.outputs['artifact-path'] }}
+      checksum-path: ${{ steps.package.outputs['checksum-path'] }}
       digest: ${{ steps.package.outputs.digest }}
 
     steps:
@@ -152,8 +152,8 @@ jobs:
         with:
           name: carbon-js-sdk-release-${{ steps.release.outputs.version }}-${{ github.run_attempt }}
           path: |
-            ${{ steps.package.outputs.artifact-path }}
-            ${{ steps.package.outputs.checksum-path }}
+            ${{ steps.package.outputs['artifact-path'] }}
+            ${{ steps.package.outputs['checksum-path'] }}
           if-no-files-found: error
           retention-days: 1
 
@@ -162,7 +162,7 @@ jobs:
           VERSION: ${{ steps.release.outputs.version }}
           COMMIT: ${{ steps.release.outputs.commit }}
           DIGEST: ${{ steps.package.outputs.digest }}
-          ARTIFACT_NAME: ${{ steps.package.outputs.artifact-name }}
+          ARTIFACT_NAME: ${{ steps.package.outputs['artifact-name'] }}
         run: |
           {
             echo "## Prebuilt release package"
@@ -191,12 +191,12 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
           RELEASE_TAG: ${{ github.ref_name }}
-          RELEASE_VERSION: ${{ needs.build-package.outputs.version }}
-          RELEASE_COMMIT: ${{ needs.build-package.outputs.commit }}
-          RELEASE_PRERELEASE: ${{ needs.build-package.outputs.prerelease }}
-          RELEASE_DIGEST: ${{ needs.build-package.outputs.digest }}
-          ARTIFACT_NAME: ${{ needs.build-package.outputs.artifact-name }}
-          EXPECTED_PUBLISHER_DIGEST: ${{ needs.prepare-publisher.outputs.publisher-digest }}
+          RELEASE_VERSION: ${{ needs['build-package'].outputs.version }}
+          RELEASE_COMMIT: ${{ needs['build-package'].outputs.commit }}
+          RELEASE_PRERELEASE: ${{ needs['build-package'].outputs.prerelease }}
+          RELEASE_DIGEST: ${{ needs['build-package'].outputs.digest }}
+          ARTIFACT_NAME: ${{ needs['build-package'].outputs['artifact-name'] }}
+          EXPECTED_PUBLISHER_DIGEST: ${{ needs['prepare-publisher'].outputs['publisher-digest'] }}
         run: |
           set -euo pipefail
           workdir="$(mktemp -d)"

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,281 @@
+name: Publish prebuilt release package
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-package-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-publisher:
+    name: Prepare trusted release tooling
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      publisher-digest: ${{ steps.publisher.outputs.digest }}
+
+    steps:
+      - name: Checkout exact publisher
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Record publisher digest
+        id: publisher
+        run: echo "digest=$(sha256sum .github/scripts/publish-release-package.sh | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Stage publisher for the write-scoped job
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: carbon-js-sdk-release-publisher
+          path: .github/scripts/publish-release-package.sh
+          if-no-files-found: error
+          retention-days: 1
+
+  build-package:
+    name: Build and validate package
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      prerelease: ${{ steps.release.outputs.prerelease }}
+      commit: ${{ steps.release.outputs.commit }}
+      artifact-name: ${{ steps.package.outputs.artifact-name }}
+      artifact-path: ${{ steps.package.outputs.artifact-path }}
+      checksum-path: ${{ steps.package.outputs.checksum-path }}
+      digest: ${{ steps.package.outputs.digest }}
+
+    steps:
+      - name: Checkout exact tagged commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Enable Yarn Classic
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+          yarn --version
+
+      - name: Validate tag, version, and commit
+        id: release
+        env:
+          TAG: ${{ github.ref_name }}
+          EVENT_COMMIT: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          tag_commit="$(git rev-parse "refs/tags/${TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          event_commit="$(git rev-parse "${EVENT_COMMIT}^{commit}")"
+          if [[ "$tag_commit" != "$head_commit" ]]; then
+            echo "Tag and checkout commits differ: tag=$tag_commit checkout=$head_commit" >&2
+            exit 1
+          fi
+          if [[ "$tag_commit" != "$event_commit" ]]; then
+            echo "Tag and event commits differ: tag=$tag_commit event=$event_commit" >&2
+            exit 1
+          fi
+
+          TAG="$TAG" node <<'NODE'
+          const fs = require("node:fs");
+          const manifest = require("./package.json");
+          const tag = process.env.TAG;
+          const semver = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+          if (!tag.startsWith("v")) throw new Error(`Version tag must start with v: ${tag}`);
+          const version = tag.slice(1);
+          if (!semver.test(version)) throw new Error(`Tag is not a strict semantic version: ${tag}`);
+          if (manifest.version !== version) {
+            throw new Error(`package.json version ${manifest.version} does not match tag ${tag}`);
+          }
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${version}\n`);
+          NODE
+
+          version="${TAG#v}"
+          version_without_build="${version%%+*}"
+          prerelease=false
+          if [[ "$version_without_build" == *-* ]]; then
+            prerelease=true
+          fi
+          {
+            echo "prerelease=$prerelease"
+            echo "commit=$tag_commit"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install frozen dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: Build SDK
+        run: yarn build
+
+      - name: Pack and validate SDK
+        id: package
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          npm pack --ignore-scripts --pack-destination dist
+          artifact_name="carbon-js-sdk-${VERSION}.tgz"
+          artifact_path="dist/${artifact_name}"
+          checksum_path="${artifact_path}.sha256"
+          if [[ ! -f "$artifact_path" ]]; then
+            echo "npm pack did not create the expected artifact: $artifact_path" >&2
+            exit 1
+          fi
+          node scripts/validate-release-package.cjs "$artifact_path" "$VERSION"
+          digest="$(sha256sum "$artifact_path" | cut -d' ' -f1)"
+          printf '%s  %s\n' "$digest" "$artifact_name" > "$checksum_path"
+          {
+            echo "artifact-name=$artifact_name"
+            echo "artifact-path=$artifact_path"
+            echo "checksum-path=$checksum_path"
+            echo "digest=$digest"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Stage package for publication job
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: carbon-js-sdk-release-${{ steps.release.outputs.version }}
+          path: |
+            ${{ steps.package.outputs.artifact-path }}
+            ${{ steps.package.outputs.checksum-path }}
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Record build provenance
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          COMMIT: ${{ steps.release.outputs.commit }}
+          DIGEST: ${{ steps.package.outputs.digest }}
+          ARTIFACT_NAME: ${{ steps.package.outputs.artifact-name }}
+        run: |
+          {
+            echo "## Prebuilt release package"
+            echo
+            echo "- Version: \`$VERSION\`"
+            echo "- Tagged commit: \`$COMMIT\`"
+            echo "- Artifact: \`$ARTIFACT_NAME\`"
+            echo "- SHA-256: \`$DIGEST\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish-release:
+    name: Publish GitHub Release assets
+    needs:
+      - build-package
+      - prepare-publisher
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - name: Download, verify, and publish release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_VERSION: ${{ needs.build-package.outputs.version }}
+          RELEASE_COMMIT: ${{ needs.build-package.outputs.commit }}
+          RELEASE_PRERELEASE: ${{ needs.build-package.outputs.prerelease }}
+          RELEASE_DIGEST: ${{ needs.build-package.outputs.digest }}
+          ARTIFACT_NAME: ${{ needs.build-package.outputs.artifact-name }}
+          EXPECTED_PUBLISHER_DIGEST: ${{ needs.prepare-publisher.outputs.publisher-digest }}
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "$workdir"' EXIT
+          mkdir -p "$workdir/publisher" "$workdir/package"
+
+          artifacts_json="$(gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}/artifacts?per_page=100")"
+          resolve_artifact_id() {
+            local name="$1"
+            local -a ids
+            mapfile -t ids < <(jq -r --arg name "$name" '.artifacts[] | select(.name == $name and .expired == false) | .id' <<< "$artifacts_json")
+            if (( ${#ids[@]} != 1 )) || [[ ! "${ids[0]}" =~ ^[0-9]+$ ]]; then
+              echo "Expected exactly one unexpired workflow artifact named $name" >&2
+              exit 1
+            fi
+            printf '%s\n' "${ids[0]}"
+          }
+
+          publisher_artifact_id="$(resolve_artifact_id carbon-js-sdk-release-publisher)"
+          package_artifact_id="$(resolve_artifact_id "carbon-js-sdk-release-${RELEASE_VERSION}")"
+          gh api "repos/${GH_REPO}/actions/artifacts/${publisher_artifact_id}/zip" > "$workdir/publisher.zip"
+          gh api "repos/${GH_REPO}/actions/artifacts/${package_artifact_id}/zip" > "$workdir/package.zip"
+
+          mapfile -t publisher_entries < <(unzip -Z1 "$workdir/publisher.zip")
+          if (( ${#publisher_entries[@]} != 1 )) || [[ "${publisher_entries[0]}" != "publish-release-package.sh" ]]; then
+            echo "Publisher workflow artifact has unexpected contents" >&2
+            exit 1
+          fi
+          mapfile -t package_entries < <(unzip -Z1 "$workdir/package.zip")
+          if (( ${#package_entries[@]} != 2 )); then
+            echo "Package workflow artifact must contain exactly two files" >&2
+            exit 1
+          fi
+          artifact_entry_found=false
+          checksum_entry_found=false
+          for entry in "${package_entries[@]}"; do
+            if [[ "$entry" == "$ARTIFACT_NAME" ]]; then
+              artifact_entry_found=true
+            elif [[ "$entry" == "$ARTIFACT_NAME.sha256" ]]; then
+              checksum_entry_found=true
+            else
+              echo "Package workflow artifact contains unexpected path: $entry" >&2
+              exit 1
+            fi
+          done
+          if [[ "$artifact_entry_found" != true || "$checksum_entry_found" != true ]]; then
+            echo "Package workflow artifact is missing the tarball or checksum" >&2
+            exit 1
+          fi
+
+          unzip -q "$workdir/publisher.zip" -d "$workdir/publisher"
+          unzip -q "$workdir/package.zip" -d "$workdir/package"
+          publisher_path="$workdir/publisher/publish-release-package.sh"
+          export RELEASE_ARTIFACT="$workdir/package/$ARTIFACT_NAME"
+          export RELEASE_CHECKSUM="$RELEASE_ARTIFACT.sha256"
+
+          publisher_digest="$(sha256sum "$publisher_path" | cut -d' ' -f1)"
+          if [[ "$publisher_digest" != "$EXPECTED_PUBLISHER_DIGEST" ]]; then
+            echo "Transferred publisher digest differs: expected $EXPECTED_PUBLISHER_DIGEST, got $publisher_digest" >&2
+            exit 1
+          fi
+          tar -tzf "$RELEASE_ARTIFACT" >/dev/null
+          actual_digest="$(sha256sum "$RELEASE_ARTIFACT" | cut -d' ' -f1)"
+          if [[ "$actual_digest" != "$RELEASE_DIGEST" ]]; then
+            echo "Transferred artifact digest differs: expected $RELEASE_DIGEST, got $actual_digest" >&2
+            exit 1
+          fi
+          if ! cmp -s "$RELEASE_CHECKSUM" <(printf '%s  %s\n' "$RELEASE_DIGEST" "$ARTIFACT_NAME"); then
+            echo "Transferred checksum file is invalid" >&2
+            exit 1
+          fi
+
+          chmod +x "$publisher_path"
+          "$publisher_path"
+
+          {
+            echo "## Published GitHub Release package"
+            echo
+            echo "- Tag: \`$RELEASE_TAG\`"
+            echo "- Tagged commit: \`$RELEASE_COMMIT\`"
+            echo "- Artifact: \`$ARTIFACT_NAME\`"
+            echo "- SHA-256: \`$RELEASE_DIGEST\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Stage publisher for the write-scoped job
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: carbon-js-sdk-release-publisher
+          name: carbon-js-sdk-release-publisher-${{ github.run_attempt }}
           path: .github/scripts/publish-release-package.sh
           if-no-files-found: error
           retention-days: 1
@@ -150,7 +150,7 @@ jobs:
       - name: Stage package for publication job
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: carbon-js-sdk-release-${{ steps.release.outputs.version }}
+          name: carbon-js-sdk-release-${{ steps.release.outputs.version }}-${{ github.run_attempt }}
           path: |
             ${{ steps.package.outputs.artifact-path }}
             ${{ steps.package.outputs.checksum-path }}
@@ -189,6 +189,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
           RELEASE_TAG: ${{ github.ref_name }}
           RELEASE_VERSION: ${{ needs.build-package.outputs.version }}
           RELEASE_COMMIT: ${{ needs.build-package.outputs.commit }}
@@ -214,8 +215,8 @@ jobs:
             printf '%s\n' "${ids[0]}"
           }
 
-          publisher_artifact_id="$(resolve_artifact_id carbon-js-sdk-release-publisher)"
-          package_artifact_id="$(resolve_artifact_id "carbon-js-sdk-release-${RELEASE_VERSION}")"
+          publisher_artifact_id="$(resolve_artifact_id "carbon-js-sdk-release-publisher-${RUN_ATTEMPT}")"
+          package_artifact_id="$(resolve_artifact_id "carbon-js-sdk-release-${RELEASE_VERSION}-${RUN_ATTEMPT}")"
           gh api "repos/${GH_REPO}/actions/artifacts/${publisher_artifact_id}/zip" > "$workdir/publisher.zip"
           gh api "repos/${GH_REPO}/actions/artifacts/${package_artifact_id}/zip" > "$workdir/package.zip"
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ Stable families include `clients`, `constants`, `hydrogen`, `insights`, `modules
 
 CommonJS and ESM each preserve singleton and class identity within their selected module graph. Loading both formats in one process creates separate module graphs, so consumers must not compare registry or class identity across `require()` and `import()` results.
 
+## Installing a prebuilt GitHub Release package
+
+Each `v*` semantic-version tag whose version matches `package.json` produces a GitHub Release containing the built CommonJS and ESM outputs. Pin the exact release asset URL when a consumer needs the tagged SDK without running this repository's `prepare` build during installation:
+
+```json
+{
+  "dependencies": {
+    "carbon-js-sdk": "https://github.com/Switcheo/carbon-js-sdk/releases/download/v0.11.76/carbon-js-sdk-0.11.76.tgz"
+  }
+}
+```
+
+The release also includes `carbon-js-sdk-<version>.tgz.sha256`. Verify that checksum when updating the pinned URL. The asset is built from the exact tagged commit and is not published to npm. Version tags are immutable release identifiers: configure an active GitHub tag ruleset for `refs/tags/v*` that blocks updates and deletions, and never force-move or reuse a pushed version tag.
+
 ## Testing and CI
 
 Run the deterministic Node test suite with:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Each `v*` semantic-version tag whose version matches `package.json` produces a G
 }
 ```
 
-The release also includes `carbon-js-sdk-<version>.tgz.sha256`. Verify that checksum when updating the pinned URL. The asset is built from the exact tagged commit and is not published to npm. Version tags are immutable release identifiers: configure an active GitHub tag ruleset for `refs/tags/v*` that blocks updates and deletions, and never force-move or reuse a pushed version tag.
+The release also includes `carbon-js-sdk-<version>.tgz.sha256`. Verify that checksum when updating the pinned URL. The asset is built from the exact tagged commit and is not published to npm. Version tags are immutable release identifiers: configure an active GitHub tag ruleset for `v*` (shown as `refs/tags/v*` by the API) that blocks updates and deletions, and never force-move or reuse a pushed version tag. Maintainers should follow the [GitHub Release playbook](./RELEASE.md).
 
 ## Testing and CI
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,131 @@
+# GitHub Release playbook
+
+This repository publishes a prebuilt npm tarball to GitHub Releases. It does not publish to npm.
+
+## One-time setup
+
+1. Merge the release-package workflow into the default `staging` branch.
+2. In **Settings → Rules → Rulesets**, create an active tag ruleset targeting `v*`.
+   - GitHub's tag-ruleset UI adds the `refs/tags/` prefix automatically.
+   - The Rulesets API must show exactly `refs/tags/v*`, not `refs/tags/refs/tags/v*`.
+   - Enable **Restrict updates**, **Restrict deletions**, and **Block force pushes**.
+   - Leave **Restrict creations** disabled so new version tags can be pushed.
+3. Before the first production release, complete the sandbox test below.
+
+Verify the configured pattern:
+
+```bash
+RULESET_ID="$(
+  gh api 'repos/Switcheo/carbon-js-sdk/rulesets?includes_parents=true' \
+    --jq '.[] | select(.target == "tag" and .name == "Immutable version tags") | .id'
+)"
+gh api "repos/Switcheo/carbon-js-sdk/rulesets/$RULESET_ID" \
+  --jq '{name, enforcement, include: .conditions.ref_name.include, rules: [.rules[].type]}'
+```
+
+## Prepare a release
+
+1. Update `package.json` to the intended strict SemVer version through a normal PR.
+2. Merge the version change into `staging` only after required CI passes.
+3. Check out the exact current `staging` commit with a clean worktree:
+
+```bash
+git fetch origin
+git switch staging
+git pull --ff-only origin staging
+git status --short
+VERSION="$(node -p 'require("./package.json").version')"
+printf 'release version: %s\ncommit: %s\n' "$VERSION" "$(git rev-parse HEAD)"
+```
+
+Do not proceed if the worktree is dirty, CI is failing, or the version is not the intended release.
+
+## Publish
+
+Create one annotated tag at the reviewed `staging` commit and push it once:
+
+```bash
+git tag -a "v$VERSION" -m "carbon-js-sdk v$VERSION"
+git push origin "v$VERSION"
+```
+
+Never move, delete, or reuse a pushed version tag. A correction must use a new version.
+
+The tag push starts **Publish prebuilt release package**. The workflow:
+
+1. Captures trusted publisher code in a read-only job.
+2. Builds and validates the SDK with Node and Yarn versions pinned by the repository.
+3. Runs `npm pack --ignore-scripts` without publishing to npm.
+4. Creates the corresponding GitHub Release and uploads:
+   - `carbon-js-sdk-<version>.tgz`
+   - `carbon-js-sdk-<version>.tgz.sha256`
+
+## Monitor
+
+```bash
+RUN_ID="$(
+  gh run list \
+    --repo Switcheo/carbon-js-sdk \
+    --workflow release-package.yml \
+    --limit 1 \
+    --json databaseId \
+    --jq '.[0].databaseId'
+)"
+
+gh run watch "$RUN_ID" \
+  --repo Switcheo/carbon-js-sdk \
+  --exit-status
+```
+
+## Verify the release
+
+```bash
+gh release view "v$VERSION" \
+  --repo Switcheo/carbon-js-sdk \
+  --json url,tagName,isPrerelease,targetCommitish,assets
+
+VERIFY_DIR="$(mktemp -d)"
+gh release download "v$VERSION" \
+  --repo Switcheo/carbon-js-sdk \
+  --dir "$VERIFY_DIR"
+
+(
+  cd "$VERIFY_DIR"
+  sha256sum --check "carbon-js-sdk-$VERSION.tgz.sha256"
+)
+```
+
+Confirm that the release contains exactly the tarball and checksum, the checksum passes, and prerelease versions such as `1.2.3-rc.1` are marked as prereleases.
+
+Test installation without lifecycle scripts:
+
+```bash
+CONSUMER_DIR="$(mktemp -d)"
+cd "$CONSUMER_DIR"
+npm init -y
+npm install --ignore-scripts "$VERIFY_DIR/carbon-js-sdk-$VERSION.tgz"
+node -e 'const sdk = require("carbon-js-sdk"); if (!sdk) throw new Error("CommonJS load failed")'
+node --input-type=module -e 'const sdk = await import("carbon-js-sdk"); if (!sdk) throw new Error("ESM load failed")'
+```
+
+## Safe reruns and recovery
+
+A failed workflow attempt can be rerun without changing the tag:
+
+```bash
+gh run rerun "$RUN_ID" --repo Switcheo/carbon-js-sdk
+gh run watch "$RUN_ID" --repo Switcheo/carbon-js-sdk --exit-status
+```
+
+Reruns accept byte-identical assets and upload missing assets. They fail instead of replacing an existing asset with different bytes.
+
+If a rerun reports conflicting bytes, malformed provenance, an unreadable release, or a moved tag:
+
+1. Stop; do not use `--clobber` and do not alter the tag.
+2. Inspect the workflow logs and existing release assets.
+3. Correct the source or release process through a new PR.
+4. Publish a new SemVer version rather than reusing the old tag.
+
+## First-release sandbox test
+
+Before the first production release, copy the PR head to a disposable private repository, set its default branch to `staging`, and push `HEAD` as `refs/tags/v<package-version>`. Verify the initial workflow run, the downloaded checksum, CommonJS and ESM installation, and a **Re-run all jobs** attempt. Delete the sandbox after recording the results.

--- a/scripts/validate-release-package.cjs
+++ b/scripts/validate-release-package.cjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/* global process, require */
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const [archive, expectedVersion] = process.argv.slice(2);
+if (!archive || !expectedVersion) {
+  console.error("usage: validate-release-package.cjs <archive.tgz> <expected-version>");
+  process.exit(1);
+}
+if (!fs.existsSync(archive)) {
+  throw new Error(`Package archive does not exist: ${archive}`);
+}
+
+function tar(...args) {
+  const result = spawnSync("tar", args, { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`tar ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout;
+}
+
+const entries = new Set(tar("-tzf", archive).split("\n").filter(Boolean));
+const required = [
+  "package/package.json",
+  "package/lib/index.js",
+  "package/lib/index.d.ts",
+  "package/esm/index.js",
+  "package/esm/package.json",
+  "package/lib/eth/abis/generated.js",
+  "package/lib/eth/abis/generated.d.ts",
+  "package/esm/eth/abis/generated.js",
+  "package/README.md",
+];
+
+function walk(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .flatMap((entry) => {
+      const absolute = path.join(directory, entry.name);
+      return entry.isDirectory() ? walk(absolute) : [absolute];
+    });
+}
+
+const sourceRoot = path.resolve(__dirname, "../src");
+const runtimeJsonAssets = walk(sourceRoot).filter((file) => file.endsWith(".json"));
+if (runtimeJsonAssets.length === 0) {
+  throw new Error("No runtime JSON assets were found under src; package validation cannot prove generated assets are present");
+}
+for (const asset of runtimeJsonAssets) {
+  const relative = path.relative(sourceRoot, asset).split(path.sep).join("/");
+  required.push(`package/lib/${relative}`, `package/esm/${relative}`);
+}
+
+const missing = required.filter((entry) => !entries.has(entry));
+if (missing.length > 0) {
+  throw new Error(`Package archive is missing required files:\n${missing.map((entry) => `- ${entry}`).join("\n")}`);
+}
+
+const manifest = JSON.parse(tar("-xOzf", archive, "package/package.json"));
+if (manifest.name !== "carbon-js-sdk") {
+  throw new Error(`Packed package name is ${manifest.name}; expected carbon-js-sdk`);
+}
+if (manifest.version !== expectedVersion) {
+  throw new Error(`Packed package version is ${manifest.version}; expected ${expectedVersion}`);
+}
+
+console.log(`validated ${required.length} required package files, including ${runtimeJsonAssets.length} JSON assets in both builds`);

--- a/tests/release-package-publishing.test.cjs
+++ b/tests/release-package-publishing.test.cjs
@@ -10,6 +10,7 @@ const test = require("node:test");
 
 const root = path.resolve(__dirname, "..");
 const publisher = path.join(root, ".github/scripts/publish-release-package.sh");
+const workflow = path.join(root, ".github/workflows/release-package.yml");
 const tag = "v1.2.3";
 const version = "1.2.3";
 const commit = "0123456789abcdef0123456789abcdef01234567";
@@ -185,6 +186,20 @@ process.exit(92);
 function cleanup(fixture) {
   fs.rmSync(fixture.workspace, { recursive: true, force: true });
 }
+
+test("workflow uses bracket notation for hyphenated expression keys", () => {
+  const contents = fs.readFileSync(workflow, "utf8");
+  const expressions = [...contents.matchAll(/\$\{\{([\s\S]*?)\}\}/g)].map((match) => match[1]);
+  for (const expression of expressions) {
+    assert.doesNotMatch(
+      expression,
+      /(?:^|\.)[A-Za-z_][A-Za-z0-9_]*-[A-Za-z0-9_-]*(?=\.|\s|$)/,
+      `GitHub rejects dot notation for hyphenated expression keys: ${expression}`,
+    );
+  }
+  assert.match(contents, /needs\['build-package'\]/);
+  assert.match(contents, /outputs\['artifact-name'\]/);
+});
 
 test("rerun leaves byte-identical release assets unchanged", () => {
   const fixture = setupFixture();

--- a/tests/release-package-publishing.test.cjs
+++ b/tests/release-package-publishing.test.cjs
@@ -1,0 +1,308 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global __dirname, Buffer, process, require */
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const root = path.resolve(__dirname, "..");
+const publisher = path.join(root, ".github/scripts/publish-release-package.sh");
+const tag = "v1.2.3";
+const version = "1.2.3";
+const commit = "0123456789abcdef0123456789abcdef01234567";
+
+function digest(contents) {
+  return crypto.createHash("sha256").update(contents).digest("hex");
+}
+
+function provenance(artifactDigest) {
+  return [
+    "<!-- carbon-js-sdk-prebuilt-provenance -->",
+    "## Prebuilt package provenance",
+    "",
+    `- Tagged commit: \`${commit}\``,
+    `- Artifact SHA-256: \`${artifactDigest}\``,
+    "<!-- /carbon-js-sdk-prebuilt-provenance -->",
+    "",
+  ].join("\n");
+}
+
+function setupFixture({
+  releaseExists = true,
+  remoteArtifact,
+  includeRemoteChecksum = true,
+  prerelease = false,
+  remoteNotes,
+  remoteCommit = commit,
+  checksumOverride,
+  releaseReadFailure = false,
+} = {}) {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "carbon-release-package-"));
+  const bin = path.join(workspace, "bin");
+  const local = path.join(workspace, "local");
+  const remote = path.join(workspace, "remote");
+  const log = path.join(workspace, "gh.log");
+  fs.mkdirSync(bin);
+  fs.mkdirSync(local);
+  fs.mkdirSync(remote);
+
+  const artifactName = `carbon-js-sdk-${version}.tgz`;
+  const checksumName = `${artifactName}.sha256`;
+  const artifactContents = Buffer.from("prebuilt package bytes");
+  const artifactDigest = digest(artifactContents);
+  const checksumContents = Buffer.from(checksumOverride ?? `${artifactDigest}  ${artifactName}\n`);
+  const artifact = path.join(local, artifactName);
+  const checksum = path.join(local, checksumName);
+  fs.writeFileSync(artifact, artifactContents);
+  fs.writeFileSync(checksum, checksumContents);
+  fs.writeFileSync(path.join(remote, "notes.md"), remoteNotes ?? provenance(artifactDigest));
+
+  if (remoteArtifact !== null) {
+    fs.writeFileSync(path.join(remote, artifactName), remoteArtifact ?? artifactContents);
+  }
+  if (includeRemoteChecksum) {
+    fs.writeFileSync(path.join(remote, checksumName), checksumContents);
+  }
+
+  const fakeGh = path.join(bin, "gh");
+  fs.writeFileSync(
+    fakeGh,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+const remote = process.env.FAKE_REMOTE_DIR;
+const log = process.env.FAKE_GH_LOG;
+const exists = process.env.FAKE_RELEASE_EXISTS === "true";
+const record = () => fs.appendFileSync(log, JSON.stringify(args) + "\\n");
+if (args[0] === "api") {
+  const endpoint = args.find(arg => arg.startsWith("repos/"));
+  if (endpoint?.includes("/git/ref/tags/")) {
+    console.log("commit " + process.env.FAKE_REMOTE_COMMIT);
+    process.exit(0);
+  }
+  if (endpoint?.includes("/releases/tags/")) {
+    if (process.env.FAKE_RELEASE_READ_FAILURE === "true") {
+      if (args.includes("--include")) console.log("HTTP/2.0 503 Service Unavailable");
+      console.error("gh: service unavailable (HTTP 503)");
+      process.exit(1);
+    }
+    if (args.includes("--include")) {
+      console.log(exists ? "HTTP/2.0 200 OK" : "HTTP/2.0 404 Not Found");
+      process.exit(exists ? 0 : 1);
+    }
+    if (!exists) process.exit(1);
+    const assets = fs.readdirSync(remote)
+      .filter(name => name !== "notes.md")
+      .sort()
+      .map(name => ({ name }));
+    const body = fs.readFileSync(path.join(remote, "notes.md"), "utf8");
+    console.log(JSON.stringify({ assets, body, prerelease: process.env.FAKE_REMOTE_PRERELEASE === "true" }));
+    process.exit(0);
+  }
+  process.exit(89);
+}
+if (args[0] !== "release") process.exit(90);
+if (args[1] === "view") {
+  if (!exists) process.exit(1);
+  const jsonIndex = args.indexOf("--json");
+  if (jsonIndex === -1) process.exit(0);
+  const field = args[jsonIndex + 1];
+  if (field === "assets") {
+    for (const name of fs.readdirSync(remote).filter(name => name !== "notes.md").sort()) console.log(name);
+  } else if (field === "body") {
+    process.stdout.write(fs.readFileSync(path.join(remote, "notes.md"), "utf8"));
+  } else if (field === "isPrerelease") {
+    console.log(process.env.FAKE_REMOTE_PRERELEASE);
+  } else process.exit(91);
+  process.exit(0);
+}
+if (args[1] === "download") {
+  const name = args[args.indexOf("--pattern") + 1];
+  const destination = args[args.indexOf("--dir") + 1];
+  fs.copyFileSync(path.join(remote, name), path.join(destination, name));
+  process.exit(0);
+}
+if (["create", "edit", "upload"].includes(args[1])) {
+  record();
+  process.exit(0);
+}
+process.exit(92);
+`,
+    { mode: 0o755 },
+  );
+
+  const result = spawnSync("bash", [publisher], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      FAKE_REMOTE_DIR: remote,
+      FAKE_GH_LOG: log,
+      FAKE_RELEASE_EXISTS: String(releaseExists),
+      FAKE_REMOTE_PRERELEASE: String(prerelease),
+      FAKE_REMOTE_COMMIT: remoteCommit,
+      FAKE_RELEASE_READ_FAILURE: String(releaseReadFailure),
+      GH_TOKEN: "test-token",
+      GH_REPO: "Switcheo/carbon-js-sdk",
+      RELEASE_TAG: tag,
+      RELEASE_VERSION: version,
+      RELEASE_COMMIT: commit,
+      RELEASE_PRERELEASE: String(prerelease),
+      RELEASE_ARTIFACT: artifact,
+      RELEASE_CHECKSUM: checksum,
+      RELEASE_DIGEST: artifactDigest,
+    },
+  });
+
+  const calls = fs.existsSync(log)
+    ? fs.readFileSync(log, "utf8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+    : [];
+  return { workspace, result, calls, artifactName, checksumName };
+}
+
+function cleanup(fixture) {
+  fs.rmSync(fixture.workspace, { recursive: true, force: true });
+}
+
+test("rerun leaves byte-identical release assets unchanged", () => {
+  const fixture = setupFixture();
+  try {
+    assert.equal(fixture.result.status, 0, fixture.result.stderr);
+    assert.match(fixture.result.stdout, /identical bytes; leaving it unchanged/);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("rerun fails instead of replacing an asset with different bytes", () => {
+  const fixture = setupFixture({ remoteArtifact: Buffer.from("different remote bytes") });
+  try {
+    assert.notEqual(fixture.result.status, 0);
+    assert.match(fixture.result.stderr, /Refusing to replace existing release asset/);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("publisher rejects a force-moved remote tag before mutating a release", () => {
+  const fixture = setupFixture({ releaseExists: false, remoteCommit: "f".repeat(40) });
+  try {
+    assert.notEqual(fixture.result.status, 0);
+    assert.match(fixture.result.stderr, /Remote tag .* does not resolve to tagged commit/);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("publisher rejects a checksum file that does not bind the artifact digest and name", () => {
+  const fixture = setupFixture({ releaseExists: false, checksumOverride: "not-a-valid-checksum\n" });
+  try {
+    assert.notEqual(fixture.result.status, 0);
+    assert.match(fixture.result.stderr, /Checksum file does not contain the expected digest and artifact name/);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("publisher requires the checksum file's exact newline-terminated bytes", () => {
+  const artifactDigest = digest(Buffer.from("prebuilt package bytes"));
+  const checksumWithoutNewline = `${artifactDigest}  carbon-js-sdk-${version}.tgz`;
+  const fixture = setupFixture({ releaseExists: false, checksumOverride: checksumWithoutNewline });
+  try {
+    assert.notEqual(fixture.result.status, 0);
+    assert.match(fixture.result.stderr, /Checksum file does not contain the expected digest and artifact name/);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("publisher rejects trailing binary data in the checksum file", () => {
+  const artifactDigest = digest(Buffer.from("prebuilt package bytes"));
+  const expectedLine = Buffer.from(`${artifactDigest}  carbon-js-sdk-${version}.tgz\n`);
+  const fixture = setupFixture({
+    releaseExists: false,
+    checksumOverride: Buffer.concat([expectedLine, Buffer.from([0])]),
+  });
+  try {
+    assert.notEqual(fixture.result.status, 0);
+    assert.match(fixture.result.stderr, /Checksum file does not contain the expected digest and artifact name/);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("publisher fails closed when GitHub release state cannot be read", () => {
+  const fixture = setupFixture({ releaseExists: false, releaseReadFailure: true });
+  try {
+    assert.notEqual(fixture.result.status, 0);
+    assert.match(fixture.result.stderr, /Unable to determine GitHub Release state.*HTTP 503/);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("publisher rejects duplicate or contradictory provenance blocks", () => {
+  const artifactDigest = digest(Buffer.from("prebuilt package bytes"));
+  const fixture = setupFixture({ remoteNotes: `${provenance(artifactDigest)}\n${provenance("f".repeat(64))}` });
+  try {
+    assert.notEqual(fixture.result.status, 0);
+    assert.match(fixture.result.stderr, /exactly one complete prebuilt-package provenance block/);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("existing human release notes without provenance remain unchanged", () => {
+  const fixture = setupFixture({ remoteNotes: "Human-authored release notes.\n" });
+  try {
+    assert.equal(fixture.result.status, 0, fixture.result.stderr);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("rerun uploads only a missing checksum asset", () => {
+  const fixture = setupFixture({ includeRemoteChecksum: false });
+  try {
+    assert.equal(fixture.result.status, 0, fixture.result.stderr);
+    assert.equal(fixture.calls.length, 1);
+    assert.equal(fixture.calls[0][1], "upload");
+    assert.equal(fixture.calls[0].some((arg) => arg.endsWith(fixture.checksumName)), true);
+    assert.equal(fixture.calls[0].some((arg) => arg.endsWith(fixture.artifactName)), false);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("new prerelease is created for the exact tag and commit before both assets upload", () => {
+  const fixture = setupFixture({ releaseExists: false, prerelease: true });
+  try {
+    assert.equal(fixture.result.status, 0, fixture.result.stderr);
+    assert.equal(fixture.calls.length, 2);
+    const [create, upload] = fixture.calls;
+    assert.deepEqual(create.slice(0, 3), ["release", "create", tag]);
+    assert.equal(create.includes("--verify-tag"), true);
+    assert.equal(create.includes("--generate-notes"), true);
+    assert.equal(create.includes("--prerelease"), true);
+    assert.equal(create[create.indexOf("--target") + 1], commit);
+    assert.equal(upload[1], "upload");
+    assert.equal(upload.some((arg) => arg.endsWith(fixture.artifactName)), true);
+    assert.equal(upload.some((arg) => arg.endsWith(fixture.checksumName)), true);
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tests/release-package-publishing.test.cjs
+++ b/tests/release-package-publishing.test.cjs
@@ -39,6 +39,7 @@ function setupFixture({
   remoteCommit = commit,
   checksumOverride,
   releaseReadFailure = false,
+  annotatedRemoteTag = false,
 } = {}) {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "carbon-release-package-"));
   const bin = path.join(workspace, "bin");
@@ -81,7 +82,22 @@ const record = () => fs.appendFileSync(log, JSON.stringify(args) + "\\n");
 if (args[0] === "api") {
   const endpoint = args.find(arg => arg.startsWith("repos/"));
   if (endpoint?.includes("/git/ref/tags/")) {
-    console.log("commit " + process.env.FAKE_REMOTE_COMMIT);
+    if (process.env.FAKE_ANNOTATED_REMOTE_TAG === "true") {
+      console.log("tag " + "a".repeat(40));
+    } else {
+      console.log("commit " + process.env.FAKE_REMOTE_COMMIT);
+    }
+    process.exit(0);
+  }
+  if (endpoint?.includes("/git/tags/")) {
+    const objectSha = endpoint.split("/").at(-1);
+    if (objectSha === "a".repeat(40)) {
+      console.log("tag " + "b".repeat(40));
+    } else if (objectSha === "b".repeat(40)) {
+      console.log("commit " + process.env.FAKE_REMOTE_COMMIT);
+    } else {
+      process.exit(88);
+    }
     process.exit(0);
   }
   if (endpoint?.includes("/releases/tags/")) {
@@ -147,6 +163,7 @@ process.exit(92);
       FAKE_REMOTE_PRERELEASE: String(prerelease),
       FAKE_REMOTE_COMMIT: remoteCommit,
       FAKE_RELEASE_READ_FAILURE: String(releaseReadFailure),
+      FAKE_ANNOTATED_REMOTE_TAG: String(annotatedRemoteTag),
       GH_TOKEN: "test-token",
       GH_REPO: "Switcheo/carbon-js-sdk",
       RELEASE_TAG: tag,
@@ -185,6 +202,17 @@ test("rerun fails instead of replacing an asset with different bytes", () => {
   try {
     assert.notEqual(fixture.result.status, 0);
     assert.match(fixture.result.stderr, /Refusing to replace existing release asset/);
+    assert.deepEqual(fixture.calls, []);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("publisher resolves a nested annotated tag chain to the release commit", () => {
+  const fixture = setupFixture({ annotatedRemoteTag: true });
+  try {
+    assert.equal(fixture.result.status, 0, fixture.result.stderr);
+    assert.match(fixture.result.stdout, /identical bytes; leaving it unchanged/);
     assert.deepEqual(fixture.calls, []);
   } finally {
     cleanup(fixture);


### PR DESCRIPTION
## Summary

Adds an automatic GitHub Release packaging path for Carbon SDK version tags without publishing to npm.

## What changed

- Added a `v*` tag workflow that validates strict semantic-version tags against `package.json` and proves the tag, event SHA, and checked-out commit resolve to the same commit before building.
- Separates trusted publisher preparation (`contents: read`), dependency/build/package execution (`contents: read`), and publication (`actions: read`, `contents: write`) into three jobs.
- Gives the write-scoped job exactly one token-bearing shell step. It downloads run-attempt-scoped immutable workflow artifacts through the GitHub API, validates their exact ZIP paths and digests, and executes only the publisher captured by the independent read-only preparation job.
- Uses bracket notation for hyphenated GitHub Actions job and output identifiers. A live sandbox registration test caught that GitHub rejects the equivalent dot notation even though actionlint 1.7.12 accepts it; focused coverage prevents regression.
- Reuses the repository's pinned Node 24.18.0 and Yarn 1.22.22 setup, performs a frozen install and normal SDK build, then runs `npm pack --ignore-scripts` so the release asset already contains `lib/` and `esm/`.
- Validates package metadata, CommonJS/ESM roots, generated ABI outputs, README, and all runtime JSON assets before transfer. The publication job revalidates the tarball digest and the checksum file's exact bytes.
- Creates or updates the exact-tag GitHub Release with generated notes and commit/checksum provenance. SemVer prerelease tags are marked as GitHub prereleases; build metadata alone does not imply prerelease status.
- Re-resolves lightweight or annotated remote tags around release mutations and fails if the tag no longer points to the event commit. Documentation requires an active immutable `refs/tags/v*` ruleset before using the workflow.
- Makes remote reads and reruns fail closed: only an authoritative release 404 is treated as absence, identical assets are preserved, missing assets are added, and existing assets with different bytes are never replaced.
- Preserves existing human release notes while rejecting malformed, duplicate, unbalanced, or conflicting provenance blocks.
- Documents the exact GitHub Release asset URL consumers can pin and checksum verification.
- Adds `RELEASE.md`, an operator playbook covering one-time ruleset setup, release preparation, tag publication, monitoring, verification, reruns, recovery, and the first-release sandbox test.

## Why

Git dependencies run the SDK's `prepare` script during consumer installation. The prebuilt release tarball avoids that build while preserving exact tag/commit provenance, so `switcheo-disco` can install the generated package outputs directly from a pinned release URL.

## Verification

- Node 24.18.0 / Yarn 1.22.22 frozen install: passed
- `yarn test`: 181/181 passed
- Focused release publisher/workflow tests: 13/13 passed, including GitHub expression-key compatibility, byte-idempotency, lightweight and nested annotated tags, moved tags, malformed checksums, transient GitHub read failures, and provenance-note validation
- `yarn check --integrity`: passed
- `yarn check:generated`: passed
- `yarn audit:side-effects`: passed
- actionlint 1.7.12 and ShellCheck 0.10.0: passed for the new workflow and publisher
- `bash -n`, Node syntax checks, and ESLint: passed
- A live disposable private-repository tag run completed all three jobs and created the exact-commit stable release with exactly two assets. The downloaded checksum passed and the tarball digest was `0f4557be56edc1119dc0ba15db709b67cc1b3906c9129c540425ceefe0699ddd`.
- A complete GitHub Actions rerun succeeded as `run_attempt: 2`; attempt-scoped handoff artifacts were unambiguous, both existing release assets retained the same IDs and digests, and an inserted human-authored note remained byte-identical.
- Package validator confirmed 25 required entries, including eight JSON assets in both `lib/` and `esm/`
- Clean installations of the downloaded release tarball loaded 88 exports through both CommonJS and native ESM with lifecycle scripts disabled

No tag or GitHub Release was created in `Switcheo/carbon-js-sdk`, and nothing was published to npm.
