### PR TITLE
chore: bump package version to 0.11.76

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-js-sdk",
-  "version": "0.11.75",
+  "version": "0.11.76",
   "description": "TypeScript SDK for Carbon blockchain",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
## Summary

Bumps `carbon-js-sdk` from `0.11.75` to `0.11.76` for the first production run of the prebuilt GitHub Release workflow.

## Why

`v0.11.75` already exists and is protected by the immutable version-tag ruleset, so it must not be moved or reused. A new package version and tag are required.

## Verification

- Node 24.18.0 / Yarn 1.22.22
- `yarn check --integrity`: passed
- `yarn check:generated`: passed
- `yarn audit:side-effects`: passed
- `yarn test`: 181/181 passed
- Two `npm pack --ignore-scripts` runs: byte-identical
- Package validator: all 25 required entries passed

After merge, the exact merged `staging` commit will be tagged once as `v0.11.76`; the tag-triggered workflow will create and verify the GitHub Release assets. Nothing will be published to npm.
