### PR TITLE
chore: bump package version to 0.11.77

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-js-sdk",
-  "version": "0.11.76",
+  "version": "0.11.77",
   "description": "TypeScript SDK for Carbon blockchain",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/src/util/auth.ts
+++ b/src/util/auth.ts
@@ -1,5 +1,6 @@
 import { Network } from '@carbon-sdk/constant'
 import dayjs from 'dayjs'
+import { jwtDecode } from 'jwt-decode'
 
 export const expirybufferSeconds = 30
 
@@ -15,6 +16,28 @@ export enum GrantType {
   SignatureCosmos = 'signature_cosmos',
   SignatureEth = 'signature_eth',
   RefreshToken = 'refresh_token',
+}
+
+export const JWT_ACCESS_TOKEN_USE = 'accessToken'
+export const JWT_REFRESH_TOKEN_USE = 'refreshToken'
+export type JwtTokenUse = typeof JWT_ACCESS_TOKEN_USE | typeof JWT_REFRESH_TOKEN_USE
+
+type SessionTokenHeader = {
+  alg?: unknown
+  typ?: unknown
+}
+
+type SessionTokenClaims = {
+  iss?: unknown
+  aud?: unknown
+  sub?: unknown
+  iat?: unknown
+  exp?: unknown
+  token_use?: unknown
+}
+
+function getTokenHeaderType(tokenUse: JwtTokenUse): string {
+  return tokenUse === JWT_ACCESS_TOKEN_USE ? 'at+jwt' : 'rt+jwt'
 }
 
 export type GrantRequest = {
@@ -42,22 +65,62 @@ export const hasExpired = (exp: number = 0): boolean => {
 }
 
 export const hasRefreshTokenExpired = (refreshToken: string) => {
-  const payloadStr: string | undefined = refreshToken.split('.')[1]
-  if (!payloadStr) return true
-  const payload = JSON.parse(Buffer.from(payloadStr, 'base64').toString())
-  return hasExpired(payload.exp)
+  try {
+    const { exp } = jwtDecode<SessionTokenClaims>(refreshToken)
+    return !Number.isSafeInteger(exp) || hasExpired(exp as number)
+  } catch {
+    return true
+  }
 }
 
-export const isValidIssuer = (iss: string = '', network: Network) => {
+export const getExpectedTokenIssuer = (network: Network): string => {
   switch (network) {
     case Network.MainNet:
-      return iss === 'demex-auth'
+      return 'demex-auth'
     case Network.DevNet:
-      return iss === 'demex-auth-dev'
+      return 'demex-auth-dev'
     case Network.TestNet:
-      return iss === 'demex-auth-test'
+      return 'demex-auth-test'
     default:
-      return iss === 'demex-auth-local'
+      return 'demex-auth-local'
+  }
+}
 
+export const isValidIssuer = (iss: string = '', network: Network) =>
+  iss === getExpectedTokenIssuer(network)
+
+/**
+ * Checks whether an unverified JWT envelope is suitable for local session reuse.
+ * Resource servers remain responsible for signature verification and authorization.
+ */
+export const isSessionTokenUsable = (
+  token: string,
+  network: Network,
+  expectedTokenUse: JwtTokenUse,
+  expectedSubject: string,
+): boolean => {
+  if (typeof token !== 'string' || token.length === 0
+    || typeof expectedSubject !== 'string' || expectedSubject.length === 0) return false
+
+  try {
+    const header = jwtDecode<SessionTokenHeader>(token, { header: true })
+    const claims = jwtDecode<SessionTokenClaims>(token)
+    const expectedIssuer = getExpectedTokenIssuer(network)
+    const now = dayjs().unix()
+
+    return header.alg === 'ES256'
+      && header.typ === getTokenHeaderType(expectedTokenUse)
+      && claims.iss === expectedIssuer
+      && claims.aud === expectedIssuer
+      && claims.sub === expectedSubject
+      && claims.token_use === expectedTokenUse
+      && Number.isSafeInteger(claims.iat)
+      && Number.isSafeInteger(claims.exp)
+      && (claims.iat as number) > 0
+      && (claims.iat as number) <= now + expirybufferSeconds
+      && (claims.exp as number) > (claims.iat as number)
+      && !hasExpired(claims.exp as number)
+  } catch {
+    return false
   }
 }

--- a/src/wallet/CarbonWallet.ts
+++ b/src/wallet/CarbonWallet.ts
@@ -11,7 +11,7 @@ import { ProviderAgent } from "@carbon-sdk/constant/walletProvider";
 import { GrantModule } from "@carbon-sdk/modules/grant";
 import { AddressUtils, AuthUtils, CarbonTx, GenericUtils } from "@carbon-sdk/util";
 import { ETHAddress, SWTHAddress } from "@carbon-sdk/util/address";
-import { AccessTokenResponse, GrantRequest, GrantType, hasExpired, hasRefreshTokenExpired, isValidIssuer } from "@carbon-sdk/util/auth";
+import { AccessTokenResponse, GrantRequest, GrantType, JWT_ACCESS_TOKEN_USE, JWT_REFRESH_TOKEN_USE, isSessionTokenUsable } from "@carbon-sdk/util/auth";
 import { SmartWalletBlockchain } from "@carbon-sdk/util/blockchain";
 import { ETH_SECP256K1_TYPE } from "@carbon-sdk/util/ethermint";
 import { DEFAULT_PUBLIC_KEY_MESSAGE } from "@carbon-sdk/util/evm";
@@ -28,7 +28,6 @@ import axios from "axios";
 import { TxRaw as StargateTxRaw, TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx";
 import dayjs from "dayjs";
 import { utils } from "ethers";
-import { jwtDecode } from "jwt-decode";
 import { CarbonEIP712Signer, CarbonNonSigner, CarbonPrivateKeySigner, CarbonSigner, CarbonSignerTypes, isCarbonEIP712Signer } from "./CarbonSigner";
 import { CarbonSigningClient } from "./CarbonSigningClient";
 import { toUint8Array } from '@carbon-sdk/util/bytes'
@@ -352,14 +351,18 @@ export class CarbonWallet {
   public async reloadJwtToken(request?: GrantRequest, authMessage: string = DEFAULT_PUBLIC_KEY_MESSAGE) {
     const network = this.network;
     if (this.jwt) {
-      const { iss, exp } = jwtDecode(this.jwt.access_token)
-      if (!isValidIssuer(iss, network)) return this.getNewJwtToken(authMessage, request)
-      const accessTokenExpired = hasExpired(exp)
-      if (accessTokenExpired) {
-        if (!hasRefreshTokenExpired(this.jwt.refresh_token)) return this.refreshJwtToken(this.jwt.refresh_token)
-        return this.getNewJwtToken(authMessage, request)
+      if (isSessionTokenUsable(this.jwt.access_token, network, JWT_ACCESS_TOKEN_USE, this.bech32Address)) return
+
+      if (isSessionTokenUsable(this.jwt.refresh_token, network, JWT_REFRESH_TOKEN_USE, this.bech32Address)) {
+        try {
+          return await this.refreshJwtToken(this.jwt.refresh_token)
+        } catch (error) {
+          const status = axios.isAxiosError(error) ? error.response?.status : undefined
+          if (status !== 400 && status !== 401) throw error
+        }
       }
-      return
+
+      this.jwt = undefined
     }
     return this.getNewJwtToken(authMessage, request)
   }

--- a/tests/auth-session.test.cjs
+++ b/tests/auth-session.test.cjs
@@ -1,0 +1,218 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global Buffer, require */
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { Network } = require("../lib/constant");
+const {
+  JWT_ACCESS_TOKEN_USE,
+  JWT_REFRESH_TOKEN_USE,
+  hasRefreshTokenExpired,
+  isSessionTokenUsable,
+} = require("../lib/util/auth");
+const { CarbonWallet } = require("../lib/wallet/CarbonWallet");
+
+const now = Math.floor(Date.now() / 1000);
+
+function token({
+  alg = "ES256",
+  typ = "at+jwt",
+  iss = "demex-auth",
+  aud = "demex-auth",
+  sub = "carbon-subject",
+  iat = now - 10,
+  exp = now + 600,
+  tokenUse = "accessToken",
+} = {}) {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg, typ })}.${encode({ iss, aud, sub, iat, exp, token_use: tokenUse })}.signature`;
+}
+
+function session(overrides = {}) {
+  const subject = overrides.subject ?? "carbon-subject";
+  return {
+    access_token: overrides.accessToken ?? token({ sub: subject }),
+    refresh_token: overrides.refreshToken ?? token({
+      typ: "rt+jwt",
+      sub: subject,
+      exp: now + 3600,
+      tokenUse: "refreshToken",
+    }),
+    token_type: "Bearer",
+    expires_in: 600,
+    expires_at: now + 600,
+  };
+}
+
+function walletWithSession(jwt) {
+  const wallet = new CarbonWallet({
+    mode: "privateKey",
+    network: Network.MainNet,
+    privateKey: Buffer.alloc(32, 1),
+    jwt,
+  });
+  return wallet;
+}
+
+test("accepts only a strict access-token envelope for the expected wallet", () => {
+  const subject = "carbon-subject";
+  assert.equal(isSessionTokenUsable(token({ sub: subject }), Network.MainNet, JWT_ACCESS_TOKEN_USE, subject), true);
+
+  const invalidTokens = [
+    token({ alg: "HS256", sub: subject }),
+    token({ typ: "JWT", sub: subject }),
+    token({ iss: "demex-auth-test", sub: subject }),
+    token({ aud: "other-audience", sub: subject }),
+    token({ aud: ["demex-auth"], sub: subject }),
+    token({ sub: "another-wallet" }),
+    token({ tokenUse: "refreshToken", sub: subject }),
+    token({ iat: null, sub: subject }),
+    token({ iat: 0, sub: subject }),
+    token({ iat: -1, sub: subject }),
+    token({ exp: null, sub: subject }),
+    token({ iat: now + 120, sub: subject }),
+    token({ iat: now + 1000, exp: now + 100, sub: subject }),
+    token({ exp: now - 1, sub: subject }),
+    "malformed",
+  ];
+
+  for (const candidate of invalidTokens) {
+    assert.equal(
+      isSessionTokenUsable(candidate, Network.MainNet, JWT_ACCESS_TOKEN_USE, subject),
+      false,
+      `expected token to be unsuitable: ${candidate}`,
+    );
+  }
+});
+
+test("requires each network's exact issuer and scalar audience", () => {
+  const subject = "carbon-subject";
+  const issuers = new Map([
+    [Network.MainNet, "demex-auth"],
+    [Network.TestNet, "demex-auth-test"],
+    [Network.DevNet, "demex-auth-dev"],
+    [Network.LocalHost, "demex-auth-local"],
+  ]);
+
+  for (const [network, issuer] of issuers) {
+    const candidate = token({ iss: issuer, aud: issuer, sub: subject });
+    assert.equal(isSessionTokenUsable(candidate, network, JWT_ACCESS_TOKEN_USE, subject), true);
+  }
+});
+
+test("validates refresh-token type and fails closed on malformed payloads", () => {
+  const subject = "carbon-subject";
+  const refresh = token({
+    typ: "rt+jwt",
+    sub: subject,
+    tokenUse: "refreshToken",
+  });
+  assert.equal(isSessionTokenUsable(refresh, Network.MainNet, JWT_REFRESH_TOKEN_USE, subject), true);
+  assert.equal(hasRefreshTokenExpired(refresh), false);
+  assert.equal(hasRefreshTokenExpired("broken.payload"), true);
+});
+
+test("reuses a suitable access token without refreshing or signing", async () => {
+  const wallet = walletWithSession(session());
+  wallet.jwt = session({ subject: wallet.bech32Address });
+  let refreshed = false;
+  let signed = false;
+  wallet.refreshJwtToken = async () => { refreshed = true; };
+  wallet.getNewJwtToken = async () => { signed = true; };
+
+  await wallet.reloadJwtToken();
+
+  assert.equal(refreshed, false);
+  assert.equal(signed, false);
+});
+
+test("uses a suitable refresh token when the access token is unusable", async () => {
+  const wallet = walletWithSession(session());
+  wallet.jwt = session({
+    subject: wallet.bech32Address,
+    accessToken: token({ sub: wallet.bech32Address, exp: now - 1 }),
+  });
+  let refreshedWith;
+  let signed = false;
+  wallet.refreshJwtToken = async (refreshToken) => { refreshedWith = refreshToken; };
+  wallet.getNewJwtToken = async () => { signed = true; };
+
+  await wallet.reloadJwtToken();
+
+  assert.equal(refreshedWith, wallet.jwt.refresh_token);
+  assert.equal(signed, false);
+});
+
+for (const status of [400, 401]) {
+  test(`falls back to a fresh wallet signature when refresh is rejected with HTTP ${status}`, async () => {
+    const wallet = walletWithSession(session());
+    wallet.jwt = session({
+      subject: wallet.bech32Address,
+      accessToken: token({ sub: wallet.bech32Address, exp: now - 1 }),
+    });
+    let signed = false;
+    wallet.refreshJwtToken = async () => {
+      const error = new Error("refresh rejected");
+      error.isAxiosError = true;
+      error.response = { status };
+      throw error;
+    };
+    wallet.getNewJwtToken = async () => { signed = true; };
+
+    await wallet.reloadJwtToken();
+
+    assert.equal(signed, true);
+    assert.equal(wallet.jwt, undefined);
+  });
+}
+
+const unusableRefreshTokens = [
+  ["malformed", "not-a-jwt"],
+  ["expired", (subject) => token({ typ: "rt+jwt", sub: subject, exp: now - 1, tokenUse: "refreshToken" })],
+  ["wrong type", (subject) => token({ typ: "at+jwt", sub: subject, tokenUse: "accessToken" })],
+  ["wrong subject", () => token({ typ: "rt+jwt", sub: "another-wallet", tokenUse: "refreshToken" })],
+];
+
+for (const [description, makeRefreshToken] of unusableRefreshTokens) {
+  test(`skips an unusable ${description} refresh token and starts fresh signing`, async () => {
+    const wallet = walletWithSession(session());
+    const refreshToken = typeof makeRefreshToken === "function"
+      ? makeRefreshToken(wallet.bech32Address)
+      : makeRefreshToken;
+    wallet.jwt = session({
+      subject: wallet.bech32Address,
+      accessToken: token({ sub: wallet.bech32Address, exp: now - 1 }),
+      refreshToken,
+    });
+    let refreshAttempted = false;
+    let signed = false;
+    wallet.refreshJwtToken = async () => { refreshAttempted = true; };
+    wallet.getNewJwtToken = async () => {
+      assert.equal(wallet.jwt, undefined);
+      signed = true;
+    };
+
+    await wallet.reloadJwtToken();
+
+    assert.equal(refreshAttempted, false);
+    assert.equal(signed, true);
+  });
+}
+
+test("does not prompt for signing when refresh fails transiently", async () => {
+  const wallet = walletWithSession(session());
+  wallet.jwt = session({
+    subject: wallet.bech32Address,
+    accessToken: token({ sub: wallet.bech32Address, exp: now - 1 }),
+  });
+  const outage = new Error("service unavailable");
+  outage.isAxiosError = true;
+  outage.response = { status: 503 };
+  wallet.refreshJwtToken = async () => { throw outage; };
+  let signed = false;
+  wallet.getNewJwtToken = async () => { signed = true; };
+
+  await assert.rejects(wallet.reloadJwtToken(), outage);
+  assert.equal(signed, false);
+  assert.notEqual(wallet.jwt, undefined);
+});

--- a/tests/fixtures/side-effect-audit.json
+++ b/tests/fixtures/side-effect-audit.json
@@ -2,6 +2,6 @@
   "generatedLongInitializerEntries": 416,
   "generatedLongInitializerDigest": "d9aa75514406abb563ea4c8553e88b5bbe342df30d206f6ff7523cbbae2cc0f1",
   "eagerInitializerEntries": 245,
-  "eagerInitializerDigest": "6311ebe2f75ddf4f393d0eec7671dd726a1f03881a440cfd0e134a8b45a4ab1f",
+  "eagerInitializerDigest": "8aee81b00793c74507e4001f668135849f240c88652c6d8b97a85841afca20ae",
   "rationale": "Generated protobuf modules configure protobufjs Long once at module evaluation; all 416 setup occurrences are fingerprinted exactly without file deduplication. The eager-declaration fingerprint additionally covers all reviewed variable/static/export initializers, 75 top-level enums, and 30 top-level namespaces. Both fingerprints retain source positions, duplicate occurrences, and exact runtime-significant text. Any generated initializer, eager declaration, parser diagnostic, runtime import-equals, dependency-only import/re-export, decorator, non-empty static block, or other executable top-level statement requires explicit review before the package sideEffects allowlist remains empty."
 }


### PR DESCRIPTION
## Summary
Bumps `carbon-js-sdk` from `0.11.76` to `0.11.77` for the auth-session hardening release.

## Ordering
Stacked behind #670. Do not merge this PR first. After #670 merges with a merge commit, this PR contains only the one-line manifest version bump.

## Why
`v0.11.76` already exists and is protected by the immutable version-tag ruleset. A new immutable version/tag is required for the strict JWT session validation and refresh fallback.

## Release plan
After #670 and this PR pass CI and merge to staging, promote the complete current staging branch to master. Tag the exact merged master commit once as `v0.11.77`; the tag workflow will build, validate, checksum, and publish the GitHub Release tarball. Nothing will be published to npm.

## Preflight
- `v0.11.77` tag: absent
- `v0.11.77` Release: absent
- Immutable ruleset: active for `refs/tags/v*`
- Diff check: passed
- Candidate inherits the exact #670 source tree; hosted Node 24 CI runs independently on this head