### PR TITLE
fix(auth): support opaque refresh sessions

### DIFF
--- a/src/util/auth.ts
+++ b/src/util/auth.ts
@@ -64,7 +64,12 @@ export const hasExpired = (exp: number = 0): boolean => {
   return (currentUnix + expirybufferSeconds) >= exp
 }
 
+export const isOpaqueRefreshToken = (refreshToken: string): boolean =>
+  typeof refreshToken === 'string'
+  && /^[A-Za-z0-9_-]{42}[AEIMQUYcgkosw048]$/.test(refreshToken)
+
 export const hasRefreshTokenExpired = (refreshToken: string) => {
+  if (isOpaqueRefreshToken(refreshToken)) return false
   try {
     const { exp } = jwtDecode<SessionTokenClaims>(refreshToken)
     return !Number.isSafeInteger(exp) || hasExpired(exp as number)
@@ -93,11 +98,12 @@ export const isValidIssuer = (iss: string = '', network: Network) =>
  * Checks whether an unverified JWT envelope is suitable for local session reuse.
  * Resource servers remain responsible for signature verification and authorization.
  */
-export const isSessionTokenUsable = (
+const isJwtSessionTokenUsable = (
   token: string,
   network: Network,
   expectedTokenUse: JwtTokenUse,
   expectedSubject: string,
+  requireUnexpired: boolean,
 ): boolean => {
   if (typeof token !== 'string' || token.length === 0
     || typeof expectedSubject !== 'string' || expectedSubject.length === 0) return false
@@ -119,8 +125,29 @@ export const isSessionTokenUsable = (
       && (claims.iat as number) > 0
       && (claims.iat as number) <= now + expirybufferSeconds
       && (claims.exp as number) > (claims.iat as number)
-      && !hasExpired(claims.exp as number)
+      && (!requireUnexpired || !hasExpired(claims.exp as number))
   } catch {
     return false
   }
 }
+
+export const isSessionTokenUsable = (
+  token: string,
+  network: Network,
+  expectedTokenUse: JwtTokenUse,
+  expectedSubject: string,
+): boolean => isJwtSessionTokenUsable(token, network, expectedTokenUse, expectedSubject, true)
+
+/**
+ * Opaque refresh credentials carry no client-readable wallet or environment
+ * claims. Bind them to the strict access-token envelope returned alongside the
+ * credential, while allowing that access token itself to have expired.
+ */
+export const isRefreshSessionUsable = (
+  refreshToken: string,
+  accessToken: string,
+  network: Network,
+  expectedSubject: string,
+): boolean => isOpaqueRefreshToken(refreshToken)
+  ? isJwtSessionTokenUsable(accessToken, network, JWT_ACCESS_TOKEN_USE, expectedSubject, false)
+  : isSessionTokenUsable(refreshToken, network, JWT_REFRESH_TOKEN_USE, expectedSubject)

--- a/src/wallet/CarbonWallet.ts
+++ b/src/wallet/CarbonWallet.ts
@@ -11,7 +11,7 @@ import { ProviderAgent } from "@carbon-sdk/constant/walletProvider";
 import { GrantModule } from "@carbon-sdk/modules/grant";
 import { AddressUtils, AuthUtils, CarbonTx, GenericUtils } from "@carbon-sdk/util";
 import { ETHAddress, SWTHAddress } from "@carbon-sdk/util/address";
-import { AccessTokenResponse, GrantRequest, GrantType, JWT_ACCESS_TOKEN_USE, JWT_REFRESH_TOKEN_USE, isSessionTokenUsable } from "@carbon-sdk/util/auth";
+import { AccessTokenResponse, GrantRequest, GrantType, JWT_ACCESS_TOKEN_USE, isRefreshSessionUsable, isSessionTokenUsable } from "@carbon-sdk/util/auth";
 import { SmartWalletBlockchain } from "@carbon-sdk/util/blockchain";
 import { ETH_SECP256K1_TYPE } from "@carbon-sdk/util/ethermint";
 import { DEFAULT_PUBLIC_KEY_MESSAGE } from "@carbon-sdk/util/evm";
@@ -353,7 +353,12 @@ export class CarbonWallet {
     if (this.jwt) {
       if (isSessionTokenUsable(this.jwt.access_token, network, JWT_ACCESS_TOKEN_USE, this.bech32Address)) return
 
-      if (isSessionTokenUsable(this.jwt.refresh_token, network, JWT_REFRESH_TOKEN_USE, this.bech32Address)) {
+      if (isRefreshSessionUsable(
+        this.jwt.refresh_token,
+        this.jwt.access_token,
+        network,
+        this.bech32Address,
+      )) {
         try {
           return await this.refreshJwtToken(this.jwt.refresh_token)
         } catch (error) {

--- a/tests/auth-session.test.cjs
+++ b/tests/auth-session.test.cjs
@@ -8,11 +8,14 @@ const {
   JWT_ACCESS_TOKEN_USE,
   JWT_REFRESH_TOKEN_USE,
   hasRefreshTokenExpired,
+  isOpaqueRefreshToken,
+  isRefreshSessionUsable,
   isSessionTokenUsable,
 } = require("../lib/util/auth");
 const { CarbonWallet } = require("../lib/wallet/CarbonWallet");
 
 const now = Math.floor(Date.now() / 1000);
+const opaqueRefreshToken = Buffer.alloc(32, 7).toString("base64url");
 
 function token({
   alg = "ES256",
@@ -110,6 +113,20 @@ test("validates refresh-token type and fails closed on malformed payloads", () =
   assert.equal(isSessionTokenUsable(refresh, Network.MainNet, JWT_REFRESH_TOKEN_USE, subject), true);
   assert.equal(hasRefreshTokenExpired(refresh), false);
   assert.equal(hasRefreshTokenExpired("broken.payload"), true);
+  assert.equal(hasRefreshTokenExpired(opaqueRefreshToken), false);
+  assert.equal(isOpaqueRefreshToken(opaqueRefreshToken), true);
+  for (const malformed of [
+    "A".repeat(42),
+    "A".repeat(42) + "B",
+    `${opaqueRefreshToken}=`,
+    "A".repeat(44),
+  ]) assert.equal(isOpaqueRefreshToken(malformed), false);
+  assert.equal(isRefreshSessionUsable(
+    opaqueRefreshToken,
+    token({ iss: "demex-auth-test", aud: "demex-auth-test", sub: subject, exp: now - 1 }),
+    Network.MainNet,
+    subject,
+  ), false);
 });
 
 test("reuses a suitable access token without refreshing or signing", async () => {
@@ -141,6 +158,42 @@ test("uses a suitable refresh token when the access token is unusable", async ()
 
   assert.equal(refreshedWith, wallet.jwt.refresh_token);
   assert.equal(signed, false);
+});
+
+test("uses an opaque refresh token only when the cached access token binds it to this wallet and network", async () => {
+  const wallet = walletWithSession(session());
+  wallet.jwt = session({
+    subject: wallet.bech32Address,
+    accessToken: token({ sub: wallet.bech32Address, exp: now - 1 }),
+    refreshToken: opaqueRefreshToken,
+  });
+  let refreshedWith;
+  let signed = false;
+  wallet.refreshJwtToken = async (refreshToken) => { refreshedWith = refreshToken; };
+  wallet.getNewJwtToken = async () => { signed = true; };
+
+  await wallet.reloadJwtToken();
+
+  assert.equal(refreshedWith, opaqueRefreshToken);
+  assert.equal(signed, false);
+});
+
+test("never submits an opaque refresh token whose cached access token belongs to another wallet", async () => {
+  const wallet = walletWithSession(session());
+  wallet.jwt = session({
+    subject: wallet.bech32Address,
+    accessToken: token({ sub: "another-wallet", exp: now - 1 }),
+    refreshToken: opaqueRefreshToken,
+  });
+  let refreshAttempted = false;
+  let signed = false;
+  wallet.refreshJwtToken = async () => { refreshAttempted = true; };
+  wallet.getNewJwtToken = async () => { signed = true; };
+
+  await wallet.reloadJwtToken();
+
+  assert.equal(refreshAttempted, false);
+  assert.equal(signed, true);
 });
 
 for (const status of [400, 401]) {

--- a/tests/fixtures/side-effect-audit.json
+++ b/tests/fixtures/side-effect-audit.json
@@ -2,6 +2,6 @@
   "generatedLongInitializerEntries": 416,
   "generatedLongInitializerDigest": "d9aa75514406abb563ea4c8553e88b5bbe342df30d206f6ff7523cbbae2cc0f1",
   "eagerInitializerEntries": 245,
-  "eagerInitializerDigest": "8aee81b00793c74507e4001f668135849f240c88652c6d8b97a85841afca20ae",
+  "eagerInitializerDigest": "15270ef9e674bc6dff80a5577d786827c1271fe0adbb5e8768b7890d0e780086",
   "rationale": "Generated protobuf modules configure protobufjs Long once at module evaluation; all 416 setup occurrences are fingerprinted exactly without file deduplication. The eager-declaration fingerprint additionally covers all reviewed variable/static/export initializers, 75 top-level enums, and 30 top-level namespaces. Both fingerprints retain source positions, duplicate occurrences, and exact runtime-significant text. Any generated initializer, eager declaration, parser diagnostic, runtime import-equals, dependency-only import/re-export, decorator, non-empty static block, or other executable top-level statement requires explicit review before the package sideEffects allowlist remains empty."
 }


### PR DESCRIPTION
1|## Summary
2|
3|- recognize only canonical 32-byte unpadded base64url refresh credentials as opaque session tokens
4|- keep strict access-JWT envelope, issuer, audience, token class, wallet subject, and network binding before an opaque refresh credential may be used
5|- refresh opaque sessions without locally decoding the refresh credential
6|- fall back to a fresh wallet signature only for terminal refresh rejection (`400`/`401`), while preserving transient failures for retry
7|
8|## Why this is needed
9|
10|Demex Auth issue #13 replaces refresh JWTs with opaque single-use credentials. The previous SDK treated every refresh credential as a JWT, so an expired access token with a valid opaque refresh credential triggered another wallet signature instead of rotation. The compatibility test failed before this change and passes after it.
11|
12|## Validation
13|
14|- `corepack yarn test` under Node 24: build, ESLint, package/supply-chain checks, and 195/195 tests passed
15|- malformed, padded, wrong-length, wrong-wallet, wrong-network, rejected-refresh, and transient-failure cases covered
16|- no dependency or package-version change
17|
18|## Rollout dependency
19|
20|This is intentionally a draft. It must be merged and released before Disco updates its Carbon SDK dependency and before opaque refresh issuance is enabled. The dependent Disco coordination change is https://github.com/Switcheo/switcheo-disco/pull/4531. No package was published and no deployment occurred.
21|
22|Refs https://github.com/Switcheo/demex-auth/issues/13
23|
24|Demex Auth implementation: https://github.com/Switcheo/demex-auth/pull/17
25|