### PR TITLE
feat: authenticate wallets with server-issued challenges

### DIFF
--- a/src/CarbonSDK.ts
+++ b/src/CarbonSDK.ts
@@ -10,10 +10,11 @@ import {
   ProviderAgent,
   Network as _Network,
 } from "@carbon-sdk/constant";
-import { GenericUtils, NetworkUtils } from "@carbon-sdk/util";
+import { AuthUtils, GenericUtils, NetworkUtils } from "@carbon-sdk/util";
 import { Tendermint37Client } from "@cosmjs/tendermint-rpc";
 import { NodeHttpTransport } from "@improbable-eng/grpc-web-node-http-transport";
 import BigNumber from "bignumber.js";
+import axios from "axios";
 import * as clients from "./clients";
 import { CarbonQueryClient, HydrogenClient, InsightsQueryClient, TokenClient } from "./clients";
 import GasFee from "./clients/GasFee";
@@ -53,7 +54,7 @@ import { SWTHAddressOptions } from "./util/address";
 import { bnOrZero } from "./util/number";
 import { SimpleMap } from "./util/type";
 import { CarbonLedgerSigner, CarbonSigner, CarbonSignerTypes, CarbonWallet, CarbonWalletGenericOpts, EvmWalletOpts, RainbowKitWalletOpts } from "./wallet";
-import { GrantRequest, GrantType } from "./util/auth";
+import { GrantRequest, GrantType, JwtAuthMode } from "./util/auth";
 export { CarbonTx } from "@carbon-sdk/util";
 export { CarbonSigner, CarbonSignerTypes, CarbonWallet, CarbonWalletGenericOpts, CarbonWalletInitOpts } from "@carbon-sdk/wallet";
 export * as Carbon from "./codec/carbon-models";
@@ -408,7 +409,7 @@ class CarbonSDK {
         // In the case where account does not exist on chain, still allow wallet connection.
         // Else, throw an error as per normal
         if (!errorTyped.message.includes("Account does not exist on chain. Send some tokens there before trying to query sequence.")) {
-          throw new Error(errorTyped.message);
+          throw err;
         }
       }
     }
@@ -529,6 +530,35 @@ class CarbonSDK {
     return this.connect(wallet, opts);
   }
 
+  private async createEvmChallengeCredential(
+    provider: { defaultAccount(): Promise<string>, personalSign(address: string, message: string): Promise<string> },
+    opts: CarbonWalletGenericOpts | undefined,
+    signAndRecover: (message: string) => Promise<{ publicKey: string, signature: string, message: string }>,
+  ) {
+    try {
+      await GenericUtils.callIgnoreError(() => opts?.onRequestAuth?.())
+      const walletAddress = await provider.defaultAccount()
+      const authChallengeUrl = this.configOverride.authChallengeUrl
+        ?? (this.configOverride.authUrl ? AuthUtils.challengeUrlFromAccessTokenUrl(this.configOverride.authUrl) : this.networkConfig.authChallengeUrl)
+      let response
+      try {
+        response = await axios.post(authChallengeUrl, {
+          grant_type: GrantType.SignatureEth,
+          wallet_address: walletAddress,
+        })
+      } catch (error) {
+        throw AuthUtils.sanitizeChallengeError(error)
+      }
+      const challenge = AuthUtils.validateChallengeResponse(response.data.result, GrantType.SignatureEth, walletAddress)
+      return {
+        ...(await signAndRecover(challenge.message)),
+        challengeId: challenge.challenge_id,
+      }
+    } finally {
+      await GenericUtils.callIgnoreError(() => opts?.onAuthComplete?.())
+    }
+  }
+
   public async connectWithMetamask(metamask: MetaMask, opts?: CarbonWalletGenericOpts, evmWalletOpts?: EvmWalletOpts) {
     const evmChainId = this.evmChainId;
     const addressOptions: SWTHAddressOptions = {
@@ -543,12 +573,16 @@ class CarbonSDK {
     let pubKey = evmWalletOpts?.publicKeyBase64;
     let message: string | undefined;
     let signature: string | undefined;
+    let challengeId: string | undefined;
 
     if (signMessageRequired) {
-      const result = await MetaMask.signAndRecoverPubKey(metamask, opts?.enableJwtAuth, opts?.authMessage);
+      const result = noJwtProvided && (opts?.jwtAuthMode ?? JwtAuthMode.Challenge) === JwtAuthMode.Challenge
+        ? await this.createEvmChallengeCredential(metamask, opts, (exactMessage) => MetaMask.signAndRecoverPubKeyForMessage(metamask, exactMessage))
+        : await MetaMask.signAndRecoverPubKey(metamask, opts?.enableJwtAuth, opts?.authMessage);
       pubKey = result.publicKey;
       message = result.message;
       signature = result.signature;
+      challengeId = 'challengeId' in result && typeof result.challengeId === 'string' ? result.challengeId : undefined;
     }
 
     const signer = MetaMask.createMetamaskSigner(metamask, evmChainId, pubKey!, addressOptions);
@@ -564,7 +598,12 @@ class CarbonSDK {
     })
 
     if (noJwtProvided) {
-      const authRequest: GrantRequest = {
+      const authRequest: GrantRequest = challengeId ? {
+        grant_type: GrantType.SignatureEth,
+        challenge_id: challengeId,
+        public_key: Buffer.from(pubKey!, 'base64').toString('hex'),
+        signature: signature!,
+      } : {
         grant_type: GrantType.SignatureEth,
         message: message!,
         public_key: Buffer.from(pubKey!, 'base64').toString('hex'),
@@ -590,12 +629,16 @@ class CarbonSDK {
     let pubKey = rainbowKitWalletOpts?.publicKeyBase64;
     let message: string | undefined;
     let signature: string | undefined;
+    let challengeId: string | undefined;
 
     if (signMessageRequired) {
-      const result = await RainbowKitAccount.signAndRecoverPubKey(rainbowKit, opts?.enableJwtAuth, opts?.authMessage)
+      const result = noJwtProvided && (opts?.jwtAuthMode ?? JwtAuthMode.Challenge) === JwtAuthMode.Challenge
+        ? await this.createEvmChallengeCredential(rainbowKit, opts, (exactMessage) => RainbowKitAccount.signAndRecoverPubKeyForMessage(rainbowKit, exactMessage))
+        : await RainbowKitAccount.signAndRecoverPubKey(rainbowKit, opts?.enableJwtAuth, opts?.authMessage)
       pubKey = result.publicKey
       message = result.message
       signature = result.signature
+      challengeId = 'challengeId' in result && typeof result.challengeId === 'string' ? result.challengeId : undefined
     }
 
     const signer = RainbowKitAccount.createRainbowKitSigner(rainbowKit, evmChainId, pubKey!, addressOptions);
@@ -612,7 +655,12 @@ class CarbonSDK {
     });
 
     if (noJwtProvided) {
-      const authRequest: GrantRequest = {
+      const authRequest: GrantRequest = challengeId ? {
+        grant_type: GrantType.SignatureEth,
+        challenge_id: challengeId,
+        public_key: Buffer.from(pubKey!, 'base64').toString('hex'),
+        signature: signature!,
+      } : {
         grant_type: GrantType.SignatureEth,
         message: message!,
         public_key: Buffer.from(pubKey!, 'base64').toString('hex'),

--- a/src/CarbonSDK.ts
+++ b/src/CarbonSDK.ts
@@ -530,36 +530,63 @@ class CarbonSDK {
     return this.connect(wallet, opts);
   }
 
+  private async notifyAuthRequest(opts?: CarbonWalletGenericOpts) {
+    try {
+      await opts?.onRequestAuth?.()
+    } catch (_callbackError) {
+      // Authentication must not be changed by UI lifecycle callbacks.
+    }
+  }
+
+  private async notifyAuthComplete(opts?: CarbonWalletGenericOpts, error?: unknown) {
+    try {
+      const lifecycleError = error instanceof AuthUtils.WalletAuthenticationError
+        ? error
+        : error === undefined ? undefined : new Error('Wallet authentication failed.')
+      await opts?.onAuthComplete?.(lifecycleError)
+    } catch (_callbackError) {
+      // Authentication results must not be changed by UI lifecycle callbacks.
+    }
+  }
+
   private async createEvmChallengeCredential(
     provider: { defaultAccount(): Promise<string>, personalSign(address: string, message: string): Promise<string> },
-    opts: CarbonWalletGenericOpts | undefined,
     signAndRecover: (message: string) => Promise<{ publicKey: string, signature: string, message: string }>,
   ) {
+    const walletAddress = await provider.defaultAccount()
+    const authChallengeUrl = this.configOverride.authChallengeUrl
+      ?? (this.configOverride.authUrl ? AuthUtils.challengeUrlFromAccessTokenUrl(this.configOverride.authUrl) : this.networkConfig.authChallengeUrl)
+    let response
     try {
-      await GenericUtils.callIgnoreError(() => opts?.onRequestAuth?.())
-      const walletAddress = await provider.defaultAccount()
-      const authChallengeUrl = this.configOverride.authChallengeUrl
-        ?? (this.configOverride.authUrl ? AuthUtils.challengeUrlFromAccessTokenUrl(this.configOverride.authUrl) : this.networkConfig.authChallengeUrl)
-      let response
-      try {
-        response = await axios.post(authChallengeUrl, {
-          grant_type: GrantType.SignatureEth,
-          wallet_address: walletAddress,
-        })
-      } catch (error) {
-        throw AuthUtils.sanitizeChallengeError(error)
-      }
-      const challenge = AuthUtils.validateChallengeResponse(response.data.result, GrantType.SignatureEth, walletAddress)
-      return {
-        ...(await signAndRecover(challenge.message)),
-        challengeId: challenge.challenge_id,
-      }
-    } finally {
-      await GenericUtils.callIgnoreError(() => opts?.onAuthComplete?.())
+      response = await axios.post(authChallengeUrl, {
+        grant_type: GrantType.SignatureEth,
+        wallet_address: walletAddress,
+      })
+    } catch (error) {
+      throw AuthUtils.sanitizeChallengeError(error)
+    }
+    const challenge = AuthUtils.validateChallengeResponse(response.data?.result, GrantType.SignatureEth, walletAddress)
+    return {
+      ...(await signAndRecover(challenge.message)),
+      challengeId: challenge.challenge_id,
     }
   }
 
   public async connectWithMetamask(metamask: MetaMask, opts?: CarbonWalletGenericOpts, evmWalletOpts?: EvmWalletOpts) {
+    const managesAuthLifecycle = Boolean(opts?.enableJwtAuth && !opts.jwt)
+    if (managesAuthLifecycle) await this.notifyAuthRequest(opts)
+    let wallet: CarbonWallet
+    try {
+      wallet = await this.connectWithMetamaskInternal(metamask, opts, evmWalletOpts)
+      if (managesAuthLifecycle) await this.notifyAuthComplete(opts)
+    } catch (error) {
+      if (managesAuthLifecycle) await this.notifyAuthComplete(opts, error)
+      throw error
+    }
+    return this.connect(wallet, opts)
+  }
+
+  private async connectWithMetamaskInternal(metamask: MetaMask, opts?: CarbonWalletGenericOpts, evmWalletOpts?: EvmWalletOpts) {
     const evmChainId = this.evmChainId;
     const addressOptions: SWTHAddressOptions = {
       network: this.networkConfig.network,
@@ -577,7 +604,7 @@ class CarbonSDK {
 
     if (signMessageRequired) {
       const result = noJwtProvided && (opts?.jwtAuthMode ?? JwtAuthMode.Challenge) === JwtAuthMode.Challenge
-        ? await this.createEvmChallengeCredential(metamask, opts, (exactMessage) => MetaMask.signAndRecoverPubKeyForMessage(metamask, exactMessage))
+        ? await this.createEvmChallengeCredential(metamask, (exactMessage) => MetaMask.signAndRecoverPubKeyForMessage(metamask, exactMessage))
         : await MetaMask.signAndRecoverPubKey(metamask, opts?.enableJwtAuth, opts?.authMessage);
       pubKey = result.publicKey;
       message = result.message;
@@ -612,10 +639,24 @@ class CarbonSDK {
       await wallet.reloadJwtToken(authRequest, opts?.authMessage)
     }
 
-    return this.connect(wallet, opts);
+    return wallet
   }
 
   public async connectWithRainbowKit(rainbowKit: RainbowKitAccount, rainbowKitWalletOpts: RainbowKitWalletOpts, opts?: CarbonWalletGenericOpts) {
+    const managesAuthLifecycle = Boolean(opts?.enableJwtAuth && !opts.jwt)
+    if (managesAuthLifecycle) await this.notifyAuthRequest(opts)
+    let wallet: CarbonWallet
+    try {
+      wallet = await this.connectWithRainbowKitInternal(rainbowKit, rainbowKitWalletOpts, opts)
+      if (managesAuthLifecycle) await this.notifyAuthComplete(opts)
+    } catch (error) {
+      if (managesAuthLifecycle) await this.notifyAuthComplete(opts, error)
+      throw error
+    }
+    return this.connect(wallet, opts)
+  }
+
+  private async connectWithRainbowKitInternal(rainbowKit: RainbowKitAccount, rainbowKitWalletOpts: RainbowKitWalletOpts, opts?: CarbonWalletGenericOpts) {
     const evmChainId = this.evmChainId;
     const addressOptions: SWTHAddressOptions = {
       network: this.networkConfig.network,
@@ -633,7 +674,7 @@ class CarbonSDK {
 
     if (signMessageRequired) {
       const result = noJwtProvided && (opts?.jwtAuthMode ?? JwtAuthMode.Challenge) === JwtAuthMode.Challenge
-        ? await this.createEvmChallengeCredential(rainbowKit, opts, (exactMessage) => RainbowKitAccount.signAndRecoverPubKeyForMessage(rainbowKit, exactMessage))
+        ? await this.createEvmChallengeCredential(rainbowKit, (exactMessage) => RainbowKitAccount.signAndRecoverPubKeyForMessage(rainbowKit, exactMessage))
         : await RainbowKitAccount.signAndRecoverPubKey(rainbowKit, opts?.enableJwtAuth, opts?.authMessage)
       pubKey = result.publicKey
       message = result.message
@@ -669,7 +710,7 @@ class CarbonSDK {
       await wallet.reloadJwtToken(authRequest, opts?.authMessage);
     }
 
-    return this.connect(wallet, opts);
+    return wallet
   }
 
   public async connectViewOnly(bech32Address: string, opts?: CarbonWalletGenericOpts) {

--- a/src/constant/network.ts
+++ b/src/constant/network.ts
@@ -61,6 +61,7 @@ export interface NetworkConfig {
   wsUrl: string;
   faucetUrl: string;
   authUrl: string;
+  authChallengeUrl: string;
   Bech32Prefix: string;
 
   network: Network;
@@ -114,6 +115,7 @@ export const NetworkConfigs: {
     hydrogenUrl: "https://hydrogen-api.carbon.network",
     wsUrl: "wss://ws-api.carbon.network/ws",
     authUrl: "https://auth.dem.exchange/oauth/access_token",
+    authChallengeUrl: "https://auth.dem.exchange/oauth/challenge",
     faucetUrl: "",
 
     Bech32Prefix: "swth",
@@ -227,6 +229,7 @@ export const NetworkConfigs: {
     hydrogenUrl: "https://test-hydrogen-api.carbon.network",
     wsUrl: "wss://test-ws-api.carbon.network/ws",
     authUrl: "https://test-auth.dem.exchange/oauth/access_token",
+    authChallengeUrl: "https://test-auth.dem.exchange/oauth/challenge",
     faucetUrl: "https://test-faucet.carbon.network",
 
     Bech32Prefix: "tswth",
@@ -339,6 +342,7 @@ export const NetworkConfigs: {
     hydrogenUrl: "https://dev-hydrogen-api.carbon.network",
     wsUrl: "wss://dev-ws-api.carbon.network/ws",
     authUrl: "https://dev-auth.dem.exchange/oauth/access_token",
+    authChallengeUrl: "https://dev-auth.dem.exchange/oauth/challenge",
     faucetUrl: "https://dev-faucet.carbon.network",
 
     //* OnPrem network params for running locally
@@ -465,6 +469,7 @@ export const NetworkConfigs: {
     hydrogenUrl: "",
     wsUrl: "ws://localhost:5001/ws",
     authUrl: "http://localhost:9794/oauth/access_token",
+    authChallengeUrl: "http://localhost:9794/oauth/challenge",
     faucetUrl: "http://localhost:4500",
 
     Bech32Prefix: "tswth",

--- a/src/provider/metamask/MetaMask.ts
+++ b/src/provider/metamask/MetaMask.ts
@@ -311,8 +311,12 @@ export class MetaMask extends Eip6963Provider {
   }
 
   static async signAndRecoverPubKey(provider: MetaMask, enableJwtAuth?: boolean, customMsg: string = DEFAULT_PUBLIC_KEY_MESSAGE) {
-    const address = await provider.defaultAccount()
     const signMessage = enableJwtAuth ? AuthUtils.getAuthMessage(customMsg) : customMsg;
+    return this.signAndRecoverPubKeyForMessage(provider, signMessage)
+  }
+
+  static async signAndRecoverPubKeyForMessage(provider: Pick<MetaMask, 'defaultAccount' | 'personalSign'>, signMessage: string) {
+    const address = await provider.defaultAccount()
     const signature = await provider.personalSign(address, signMessage)
     const publicKeyHex = EvmUtils.recoverPublicKey(signMessage, signature)
     return {

--- a/src/provider/rainbowKit/RainbowKitAccount.ts
+++ b/src/provider/rainbowKit/RainbowKitAccount.ts
@@ -285,8 +285,12 @@ class RainbowKitAccount extends Eip6963Provider {
   }
 
   static async signAndRecoverPubKey(provider: RainbowKitAccount, enableJwtAuth?: boolean, customMsg: string = DEFAULT_PUBLIC_KEY_MESSAGE) {
-    const address = await provider.defaultAccount()
     const signMessage = enableJwtAuth ? AuthUtils.getAuthMessage(customMsg) : customMsg;
+    return this.signAndRecoverPubKeyForMessage(provider, signMessage)
+  }
+
+  static async signAndRecoverPubKeyForMessage(provider: Pick<RainbowKitAccount, 'defaultAccount' | 'personalSign'>, signMessage: string) {
+    const address = await provider.defaultAccount()
     const signature = await provider.personalSign(address, signMessage)
     const publicKeyHex = EvmUtils.recoverPublicKey(signMessage, signature)
 

--- a/src/util/auth.ts
+++ b/src/util/auth.ts
@@ -195,6 +195,18 @@ export const getExpectedTokenIssuer = (network: Network): string => {
 export const isValidIssuer = (iss: string = '', network: Network) =>
   iss === getExpectedTokenIssuer(network)
 
+const isCanonicalBase64UrlSegment = (segment: string): boolean => {
+  if (!/^[A-Za-z0-9_-]+$/.test(segment) || segment.length % 4 === 1) return false
+
+  const remainder = segment.length % 4
+  if (remainder === 0) return true
+
+  const finalSextet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'.indexOf(segment[segment.length - 1])
+  // Unpadded Base64URL must have zero-valued discarded padding bits. This is
+  // equivalent to decode/re-encode equality without a Node Buffer dependency.
+  return remainder === 2 ? finalSextet % 16 === 0 : finalSextet % 4 === 0
+}
+
 /**
  * Checks whether an unverified JWT envelope is suitable for local session reuse.
  * Resource servers remain responsible for signature verification and authorization.
@@ -208,6 +220,8 @@ const isJwtSessionTokenUsable = (
 ): boolean => {
   if (typeof token !== 'string' || token.length === 0
     || typeof expectedSubject !== 'string' || expectedSubject.length === 0) return false
+  const segments = token.split('.')
+  if (segments.length !== 3 || segments.some((segment) => !isCanonicalBase64UrlSegment(segment))) return false
 
   try {
     const header = jwtDecode<SessionTokenHeader>(token, { header: true })

--- a/src/util/auth.ts
+++ b/src/util/auth.ts
@@ -147,6 +147,7 @@ export const isExpiredChallengeError = (error: unknown) =>
   asChallengeHttpError(error)?.response?.status === 401 && challengeErrorReason(error) === 'expired'
 
 export const sanitizeChallengeError = (error: unknown): WalletAuthenticationError => {
+  if (error instanceof WalletAuthenticationError) return error
   const status = asChallengeHttpError(error)?.response?.status
   const reason = challengeErrorReason(error)
   if (status === 401 && reason === 'expired') return new WalletAuthenticationError('challenge_expired', status)

--- a/src/util/auth.ts
+++ b/src/util/auth.ts
@@ -1,4 +1,5 @@
 import { Network } from '@carbon-sdk/constant'
+
 import dayjs from 'dayjs'
 import { jwtDecode } from 'jwt-decode'
 
@@ -16,6 +17,65 @@ export enum GrantType {
   SignatureCosmos = 'signature_cosmos',
   SignatureEth = 'signature_eth',
   RefreshToken = 'refresh_token',
+}
+
+export const JwtAuthMode = {
+  Challenge: 'challenge',
+  Legacy: 'legacy',
+} as const
+export type JwtAuthMode = (typeof JwtAuthMode)[keyof typeof JwtAuthMode]
+
+export type ChallengeResponse = {
+  challenge_id: string
+  message: string
+  expires_at: string
+  metadata: {
+    grant_type: GrantType.SignatureCosmos | GrantType.SignatureEth
+    wallet_address: string
+    domain: string
+    uri: string
+    environment: string
+    network: string
+    chain_id: string | number
+    purpose: string
+  }
+}
+
+export class WalletAuthenticationError extends Error {
+  constructor(
+    public readonly code: 'challenge_expired' | 'challenge_rejected' | 'challenge_unavailable',
+    public readonly status?: number,
+  ) {
+    super(code === 'challenge_expired'
+      ? 'Wallet login challenge expired. Please sign the new challenge.'
+      : code === 'challenge_rejected'
+        ? 'Wallet login challenge was rejected.'
+        : 'Wallet login challenge service is unavailable.')
+    this.name = 'WalletAuthenticationError'
+  }
+}
+
+export const validateChallengeResponse = (
+  input: unknown,
+  grantType: GrantType.SignatureCosmos | GrantType.SignatureEth,
+  walletAddress: string,
+): ChallengeResponse => {
+  const challenge = input as Partial<ChallengeResponse> | undefined
+  const metadata = challenge?.metadata as Partial<ChallengeResponse['metadata']> | undefined
+  const chainIdIsValid = typeof metadata?.chain_id === 'string' || typeof metadata?.chain_id === 'number'
+  if (!challenge || typeof challenge.challenge_id !== 'string' || !/^[A-Za-z0-9_-]{43}$/.test(challenge.challenge_id)
+    || typeof challenge.message !== 'string' || challenge.message.length === 0
+    || typeof challenge.expires_at !== 'string' || !Number.isFinite(Date.parse(challenge.expires_at))
+    || !metadata || metadata.grant_type !== grantType
+    || typeof metadata.wallet_address !== 'string' || metadata.wallet_address.toLowerCase() !== walletAddress.toLowerCase()
+    || typeof metadata.domain !== 'string' || metadata.domain.length === 0
+    || typeof metadata.uri !== 'string' || metadata.uri.length === 0
+    || typeof metadata.environment !== 'string' || metadata.environment.length === 0
+    || typeof metadata.network !== 'string' || metadata.network.length === 0
+    || !chainIdIsValid
+    || typeof metadata.purpose !== 'string' || metadata.purpose.length === 0)
+    throw new WalletAuthenticationError('challenge_rejected')
+  return challenge as ChallengeResponse
 }
 
 export const JWT_ACCESS_TOKEN_USE = 'accessToken'
@@ -40,19 +100,59 @@ function getTokenHeaderType(tokenUse: JwtTokenUse): string {
   return tokenUse === JWT_ACCESS_TOKEN_USE ? 'at+jwt' : 'rt+jwt'
 }
 
-export type GrantRequest = {
-  grant_type: GrantType
-} & ({
-  message?: string
-  public_key?: string
-  signature?: string
+export type RefreshGrantRequest = {
+  grant_type: GrantType.RefreshToken
   refresh_token: string
-} | {
+}
+
+export type LegacySignatureGrantRequest = {
+  grant_type: GrantType.SignatureCosmos | GrantType.SignatureEth
   message: string
   public_key: string
   signature: string
-  refresh_token?: string
-})
+}
+
+export type ChallengeGrantRequest = {
+  grant_type: GrantType.SignatureCosmos | GrantType.SignatureEth
+  challenge_id: string
+  public_key: string
+  signature: string
+}
+
+export type GrantRequest = RefreshGrantRequest | LegacySignatureGrantRequest | ChallengeGrantRequest
+
+export const challengeUrlFromAccessTokenUrl = (authUrl: string) => {
+  const parsed = new URL(authUrl)
+  parsed.pathname = parsed.pathname.replace(/\/access_token$/, '/challenge')
+  return parsed.toString()
+}
+
+type ChallengeHttpError = {
+  isAxiosError?: boolean
+  response?: {
+    status?: number
+    data?: { error?: { errors?: { reason?: string } } }
+  }
+}
+
+const asChallengeHttpError = (error: unknown): ChallengeHttpError | undefined =>
+  error !== null && typeof error === 'object' && (error as ChallengeHttpError).isAxiosError === true
+    ? error as ChallengeHttpError
+    : undefined
+
+export const challengeErrorReason = (error: unknown): string | undefined =>
+  asChallengeHttpError(error)?.response?.data?.error?.errors?.reason
+
+export const isExpiredChallengeError = (error: unknown) =>
+  asChallengeHttpError(error)?.response?.status === 401 && challengeErrorReason(error) === 'expired'
+
+export const sanitizeChallengeError = (error: unknown): WalletAuthenticationError => {
+  const status = asChallengeHttpError(error)?.response?.status
+  const reason = challengeErrorReason(error)
+  if (status === 401 && reason === 'expired') return new WalletAuthenticationError('challenge_expired', status)
+  if (status === 400 || status === 401 || status === 403) return new WalletAuthenticationError('challenge_rejected', status)
+  return new WalletAuthenticationError('challenge_unavailable', status)
+}
 
 export const getAuthMessage = (message: string): string => {
   const timestamp = dayjs().format('YYYY/MM/DD HH:mm:ss Z')

--- a/src/wallet/CarbonWallet.ts
+++ b/src/wallet/CarbonWallet.ts
@@ -11,7 +11,7 @@ import { ProviderAgent } from "@carbon-sdk/constant/walletProvider";
 import { GrantModule } from "@carbon-sdk/modules/grant";
 import { AddressUtils, AuthUtils, CarbonTx, GenericUtils } from "@carbon-sdk/util";
 import { ETHAddress, SWTHAddress } from "@carbon-sdk/util/address";
-import { AccessTokenResponse, GrantRequest, GrantType, JWT_ACCESS_TOKEN_USE, isRefreshSessionUsable, isSessionTokenUsable } from "@carbon-sdk/util/auth";
+import { AccessTokenResponse, ChallengeGrantRequest, ChallengeResponse, GrantRequest, GrantType, JwtAuthMode, LegacySignatureGrantRequest, JWT_ACCESS_TOKEN_USE, isExpiredChallengeError, isRefreshSessionUsable, isSessionTokenUsable, sanitizeChallengeError } from "@carbon-sdk/util/auth";
 import { SmartWalletBlockchain } from "@carbon-sdk/util/blockchain";
 import { ETH_SECP256K1_TYPE } from "@carbon-sdk/util/ethermint";
 import { DEFAULT_PUBLIC_KEY_MESSAGE } from "@carbon-sdk/util/evm";
@@ -49,6 +49,9 @@ export interface CarbonWalletGenericOpts {
   gasFee?: GasFee;
   isRainbowKit?: boolean;
   enableJwtAuth?: boolean;
+  /** Challenge is the secure default. Legacy exists only for the bounded migration window. */
+  jwtAuthMode?: JwtAuthMode;
+  /** @deprecated Challenge messages are server controlled; used only in explicit legacy mode. */
   authMessage?: string;
   jwt?: AccessTokenResponse
   bech32Address?: string;
@@ -194,6 +197,7 @@ export class CarbonWallet {
   isRainbowKit: boolean = false
 
   jwt?: AccessTokenResponse
+  jwtAuthMode: JwtAuthMode
 
   // for analytics
   providerAgent?: ProviderAgent | string;
@@ -207,6 +211,7 @@ export class CarbonWallet {
   private evmChainId?: string;
 
   private gasFee?: GasFee;
+  private jwtReloadPromise?: Promise<void>;
 
   private sequenceInvalidated: boolean = false;
   private txSignManager: QueueManager<SignTxRequest>;
@@ -224,6 +229,7 @@ export class CarbonWallet {
     this.disableRetryOnSequenceError = opts.disableRetryOnSequenceError ?? false;
     this.triggerMerge = opts.triggerMerge ?? false
     this.jwt = opts?.jwt
+    this.jwtAuthMode = opts.jwtAuthMode ?? JwtAuthMode.Challenge
 
     this.gasFee = opts.gasFee;
 
@@ -320,8 +326,8 @@ export class CarbonWallet {
 
     const addressBytes = AddressUtils.SWTHAddress.getAddressBytes(this.bech32Address, this.network);
     this.hexAddress = `0x${Buffer.from(addressBytes).toString("hex")}`;
-    this.evmHexAddress = this.bech32Address ? '' : AddressUtils.ETHAddress.publicKeyToAddress(this.publicKey, addressOpts);
-    this.evmBech32Address = this.bech32Address ? '' : AddressUtils.ETHAddress.publicKeyToBech32Address(this.publicKey, addressOpts)
+    this.evmHexAddress = this.isEvmWallet() ? AddressUtils.ETHAddress.publicKeyToAddress(this.publicKey, addressOpts) : '';
+    this.evmBech32Address = this.isEvmWallet() ? AddressUtils.ETHAddress.publicKeyToBech32Address(this.publicKey, addressOpts) : ''
   }
 
   public async initialize(queryClient: CarbonQueryClient, gasFee: GasFee, fallbackConfig: OverrideConfig | null = null, opts?: CarbonWalletGenericOpts): Promise<CarbonWallet> {
@@ -349,6 +355,15 @@ export class CarbonWallet {
   }
 
   public async reloadJwtToken(request?: GrantRequest, authMessage: string = DEFAULT_PUBLIC_KEY_MESSAGE) {
+    if (this.jwtReloadPromise) return this.jwtReloadPromise
+    const wrapped = this.reloadJwtTokenInternal(request, authMessage).finally(() => {
+      if (this.jwtReloadPromise === wrapped) this.jwtReloadPromise = undefined
+    })
+    this.jwtReloadPromise = wrapped
+    return wrapped
+  }
+
+  private async reloadJwtTokenInternal(request?: GrantRequest, authMessage: string = DEFAULT_PUBLIC_KEY_MESSAGE) {
     const network = this.network;
     if (this.jwt) {
       if (isSessionTokenUsable(this.jwt.access_token, network, JWT_ACCESS_TOKEN_USE, this.bech32Address)) return
@@ -395,20 +410,64 @@ export class CarbonWallet {
   }
 
   private async getNewJwtToken(authMessage: string, request?: GrantRequest) {
+    if (request && 'message' in request && this.jwtAuthMode !== JwtAuthMode.Legacy)
+      throw new AuthUtils.WalletAuthenticationError('challenge_rejected')
     const req = request ?? await this.constructGrantRequest(authMessage)
-    const response = await axios.post(this.networkConfig.authUrl, req)
-    this.jwt = response.data.result
+    return this.redeemGrantRequest(req, authMessage, 0)
   }
 
-  private async constructGrantRequest(authMessage: string) {
+  private async redeemGrantRequest(request: GrantRequest, authMessage: string, expiredRetries: number): Promise<void> {
+    try {
+      const response = await axios.post(this.networkConfig.authUrl, request)
+      this.jwt = response.data.result
+    } catch (error) {
+      if ('challenge_id' in request && isExpiredChallengeError(error) && expiredRetries < 1) {
+        const retry = await this.constructGrantRequest(authMessage, true)
+        return this.redeemGrantRequest(retry, authMessage, expiredRetries + 1)
+      }
+      if ('challenge_id' in request) throw sanitizeChallengeError(error)
+      throw error
+    }
+  }
+
+  private getChallengeUrl() {
+    if (this.configOverride.authChallengeUrl) return this.configOverride.authChallengeUrl
+    if (this.configOverride.authUrl) return AuthUtils.challengeUrlFromAccessTokenUrl(this.configOverride.authUrl)
+    return this.networkConfig.authChallengeUrl
+  }
+
+
+  private async constructGrantRequest(authMessage: string, forceChallenge = false): Promise<ChallengeGrantRequest | LegacySignatureGrantRequest> {
     try {
       await GenericUtils.callIgnoreError(() => this.onRequestAuth?.())
       const address = this.isEvmWallet() ? this.evmHexAddress : this.bech32Address
-      const message = AuthUtils.getAuthMessage(authMessage)
-      const signature = await this.signer.signMessage(address, message)
+      const grantType = this.isEvmWallet() ? GrantType.SignatureEth : GrantType.SignatureCosmos
+      if (this.jwtAuthMode === JwtAuthMode.Legacy && !forceChallenge) {
+        const message = AuthUtils.getAuthMessage(authMessage)
+        const signature = await this.signer.signMessage(address, message)
+        return {
+          grant_type: grantType,
+          message,
+          public_key: this.publicKey.toString('hex'),
+          signature,
+        }
+      }
+
+      let challenge: ChallengeResponse
+      try {
+        const response = await axios.post(this.getChallengeUrl(), {
+          grant_type: grantType,
+          wallet_address: address,
+        })
+        challenge = response.data.result
+      } catch (error) {
+        throw sanitizeChallengeError(error)
+      }
+      challenge = AuthUtils.validateChallengeResponse(challenge, grantType, address)
+      const signature = await this.signer.signMessage(address, challenge.message)
       return {
-        grant_type: this.isEvmWallet() ? GrantType.SignatureEth : GrantType.SignatureCosmos,
-        message,
+        grant_type: grantType,
+        challenge_id: challenge.challenge_id,
         public_key: this.publicKey.toString('hex'),
         signature,
       }

--- a/src/wallet/CarbonWallet.ts
+++ b/src/wallet/CarbonWallet.ts
@@ -82,7 +82,8 @@ export interface CarbonWalletGenericOpts {
   onRequestAuth?: CarbonWallet.OnRequestAuthCallback
 
   /**
-  * Optional callback that will be called after authentication is complete
+  * Optional callback that will be called after authentication is complete.
+  * Receives the authentication failure, if any.
   */
   onAuthComplete?: CarbonWallet.OnAuthComplete
 }
@@ -410,16 +411,55 @@ export class CarbonWallet {
   }
 
   private async getNewJwtToken(authMessage: string, request?: GrantRequest) {
-    if (request && 'message' in request && this.jwtAuthMode !== JwtAuthMode.Legacy)
-      throw new AuthUtils.WalletAuthenticationError('challenge_rejected')
-    const req = request ?? await this.constructGrantRequest(authMessage)
-    return this.redeemGrantRequest(req, authMessage, 0)
+    const managesAuthLifecycle = request === undefined
+    try {
+      if (request && 'message' in request && this.jwtAuthMode !== JwtAuthMode.Legacy)
+        throw new AuthUtils.WalletAuthenticationError('challenge_rejected')
+      const req = request ?? await this.constructGrantRequest(authMessage)
+      await this.redeemGrantRequest(req, authMessage, 0)
+      if (managesAuthLifecycle) await this.notifyAuthComplete()
+    } catch (error) {
+      if (managesAuthLifecycle) await this.notifyAuthComplete(error)
+      throw error
+    }
+  }
+
+  private async notifyAuthRequest() {
+    try {
+      await this.onRequestAuth?.()
+    } catch (_callbackError) {
+      // Authentication must not be changed by UI lifecycle callbacks.
+    }
+  }
+
+  private async notifyAuthComplete(error?: unknown) {
+    try {
+      const lifecycleError = error instanceof AuthUtils.WalletAuthenticationError
+        ? error
+        : error === undefined ? undefined : new Error('Wallet authentication failed.')
+      await this.onAuthComplete?.(lifecycleError)
+    } catch (_callbackError) {
+      // Authentication results must not be changed by UI lifecycle callbacks.
+    }
   }
 
   private async redeemGrantRequest(request: GrantRequest, authMessage: string, expiredRetries: number): Promise<void> {
     try {
       const response = await axios.post(this.networkConfig.authUrl, request)
-      this.jwt = response.data.result
+      const result = response.data?.result
+      if (
+        !result
+        || typeof result !== 'object'
+        || typeof result.access_token !== 'string'
+        || typeof result.token_type !== 'string'
+        || typeof result.expires_in !== 'number'
+        || typeof result.expires_at !== 'number'
+        || typeof result.refresh_token !== 'string'
+      ) {
+        if ('challenge_id' in request) throw new AuthUtils.WalletAuthenticationError('challenge_rejected')
+        throw new Error('Wallet authentication returned an invalid token response.')
+      }
+      this.jwt = result
     } catch (error) {
       if ('challenge_id' in request && isExpiredChallengeError(error) && expiredRetries < 1) {
         const retry = await this.constructGrantRequest(authMessage, true)
@@ -438,41 +478,37 @@ export class CarbonWallet {
 
 
   private async constructGrantRequest(authMessage: string, forceChallenge = false): Promise<ChallengeGrantRequest | LegacySignatureGrantRequest> {
-    try {
-      await GenericUtils.callIgnoreError(() => this.onRequestAuth?.())
-      const address = this.isEvmWallet() ? this.evmHexAddress : this.bech32Address
-      const grantType = this.isEvmWallet() ? GrantType.SignatureEth : GrantType.SignatureCosmos
-      if (this.jwtAuthMode === JwtAuthMode.Legacy && !forceChallenge) {
-        const message = AuthUtils.getAuthMessage(authMessage)
-        const signature = await this.signer.signMessage(address, message)
-        return {
-          grant_type: grantType,
-          message,
-          public_key: this.publicKey.toString('hex'),
-          signature,
-        }
-      }
-
-      let challenge: ChallengeResponse
-      try {
-        const response = await axios.post(this.getChallengeUrl(), {
-          grant_type: grantType,
-          wallet_address: address,
-        })
-        challenge = response.data.result
-      } catch (error) {
-        throw sanitizeChallengeError(error)
-      }
-      challenge = AuthUtils.validateChallengeResponse(challenge, grantType, address)
-      const signature = await this.signer.signMessage(address, challenge.message)
+    await this.notifyAuthRequest()
+    const address = this.isEvmWallet() ? this.evmHexAddress : this.bech32Address
+    const grantType = this.isEvmWallet() ? GrantType.SignatureEth : GrantType.SignatureCosmos
+    if (this.jwtAuthMode === JwtAuthMode.Legacy && !forceChallenge) {
+      const message = AuthUtils.getAuthMessage(authMessage)
+      const signature = await this.signer.signMessage(address, message)
       return {
         grant_type: grantType,
-        challenge_id: challenge.challenge_id,
+        message,
         public_key: this.publicKey.toString('hex'),
         signature,
       }
-    } finally {
-      await GenericUtils.callIgnoreError(() => this.onAuthComplete?.())
+    }
+
+    let challenge: ChallengeResponse
+    try {
+      const response = await axios.post(this.getChallengeUrl(), {
+        grant_type: grantType,
+        wallet_address: address,
+      })
+      challenge = response.data?.result
+    } catch (error) {
+      throw sanitizeChallengeError(error)
+    }
+    challenge = AuthUtils.validateChallengeResponse(challenge, grantType, address)
+    const signature = await this.signer.signMessage(address, challenge.message)
+    return {
+      grant_type: grantType,
+      challenge_id: challenge.challenge_id,
+      public_key: this.publicKey.toString('hex'),
+      signature,
     }
   }
 
@@ -1156,7 +1192,7 @@ export namespace CarbonWallet {
   export type SendTxToMempoolWithoutConfirmResponse = BroadcastTxSyncResponse;
   export type SendTxWithoutConfirmResponse = BroadcastTxAsyncResponse;
   export type OnRequestAuthCallback = () => void | Promise<void>;
-  export type OnAuthComplete = () => void | Promise<void>;
+  export type OnAuthComplete = (error?: unknown) => void | Promise<void>;
   export type OnRequestSignCallback = (msgs: readonly EncodeObject[]) => void | Promise<void>;
   export type OnSignCompleteCallback = (signature: StdSignature | null) => void | Promise<void>;
   export type OnBroadcastTxFailCallback = (msgs: readonly EncodeObject[]) => void | Promise<void>;

--- a/src/wallet/CarbonWallet.ts
+++ b/src/wallet/CarbonWallet.ts
@@ -415,17 +415,19 @@ export class CarbonWallet {
     const invalid = !token
       || typeof token !== 'object'
       || typeof token.access_token !== 'string'
-      || token.access_token.trim().length === 0
-      || typeof token.token_type !== 'string'
-      || token.token_type.trim().length === 0
-      || typeof token.expires_in !== 'number'
-      || !Number.isFinite(token.expires_in)
-      || token.expires_in <= 0
-      || typeof token.expires_at !== 'number'
-      || !Number.isFinite(token.expires_at)
-      || token.expires_at <= 0
+      || !isSessionTokenUsable(token.access_token, this.network, JWT_ACCESS_TOKEN_USE, this.bech32Address)
+      || token.token_type !== 'Bearer'
+      || !Number.isSafeInteger(token.expires_in)
+      || (token.expires_in as number) <= 0
+      || !Number.isSafeInteger(token.expires_at)
+      || AuthUtils.hasExpired(token.expires_at as number)
       || typeof token.refresh_token !== 'string'
-      || token.refresh_token.trim().length === 0
+      || !isRefreshSessionUsable(
+        token.refresh_token,
+        token.access_token,
+        this.network,
+        this.bech32Address,
+      )
     if (invalid) {
       if (challengeGrant) throw new AuthUtils.WalletAuthenticationError('challenge_rejected')
       throw new Error('Wallet authentication returned an invalid token response.')
@@ -436,6 +438,8 @@ export class CarbonWallet {
   private async getNewJwtToken(authMessage: string, request?: GrantRequest) {
     const managesAuthLifecycle = request === undefined
     try {
+      if (request?.grant_type === GrantType.RefreshToken)
+        throw new AuthUtils.WalletAuthenticationError('challenge_rejected')
       if (request && 'message' in request && this.jwtAuthMode !== JwtAuthMode.Legacy)
         throw new AuthUtils.WalletAuthenticationError('challenge_rejected')
       const req = request ?? await this.constructGrantRequest(authMessage)

--- a/src/wallet/CarbonWallet.ts
+++ b/src/wallet/CarbonWallet.ts
@@ -407,7 +407,30 @@ export class CarbonWallet {
       refresh_token: refreshToken,
     }
     const response = await axios.post(this.networkConfig.authUrl, request)
-    this.jwt = response.data.result
+    this.jwt = this.validateTokenResponse(response.data?.result, false)
+  }
+
+  private validateTokenResponse(result: unknown, challengeGrant: boolean): AccessTokenResponse {
+    const token = result as Partial<AccessTokenResponse> | undefined
+    const invalid = !token
+      || typeof token !== 'object'
+      || typeof token.access_token !== 'string'
+      || token.access_token.trim().length === 0
+      || typeof token.token_type !== 'string'
+      || token.token_type.trim().length === 0
+      || typeof token.expires_in !== 'number'
+      || !Number.isFinite(token.expires_in)
+      || token.expires_in <= 0
+      || typeof token.expires_at !== 'number'
+      || !Number.isFinite(token.expires_at)
+      || token.expires_at <= 0
+      || typeof token.refresh_token !== 'string'
+      || token.refresh_token.trim().length === 0
+    if (invalid) {
+      if (challengeGrant) throw new AuthUtils.WalletAuthenticationError('challenge_rejected')
+      throw new Error('Wallet authentication returned an invalid token response.')
+    }
+    return token as AccessTokenResponse
   }
 
   private async getNewJwtToken(authMessage: string, request?: GrantRequest) {
@@ -446,23 +469,10 @@ export class CarbonWallet {
   private async redeemGrantRequest(request: GrantRequest, authMessage: string, expiredRetries: number): Promise<void> {
     try {
       const response = await axios.post(this.networkConfig.authUrl, request)
-      const result = response.data?.result
-      if (
-        !result
-        || typeof result !== 'object'
-        || typeof result.access_token !== 'string'
-        || typeof result.token_type !== 'string'
-        || typeof result.expires_in !== 'number'
-        || typeof result.expires_at !== 'number'
-        || typeof result.refresh_token !== 'string'
-      ) {
-        if ('challenge_id' in request) throw new AuthUtils.WalletAuthenticationError('challenge_rejected')
-        throw new Error('Wallet authentication returned an invalid token response.')
-      }
-      this.jwt = result
+      this.jwt = this.validateTokenResponse(response.data?.result, 'challenge_id' in request)
     } catch (error) {
       if ('challenge_id' in request && isExpiredChallengeError(error) && expiredRetries < 1) {
-        const retry = await this.constructGrantRequest(authMessage, true)
+        const retry = await this.constructGrantRequest(authMessage, true, false)
         return this.redeemGrantRequest(retry, authMessage, expiredRetries + 1)
       }
       if ('challenge_id' in request) throw sanitizeChallengeError(error)
@@ -477,8 +487,8 @@ export class CarbonWallet {
   }
 
 
-  private async constructGrantRequest(authMessage: string, forceChallenge = false): Promise<ChallengeGrantRequest | LegacySignatureGrantRequest> {
-    await this.notifyAuthRequest()
+  private async constructGrantRequest(authMessage: string, forceChallenge = false, notifyRequest = true): Promise<ChallengeGrantRequest | LegacySignatureGrantRequest> {
+    if (notifyRequest) await this.notifyAuthRequest()
     const address = this.isEvmWallet() ? this.evmHexAddress : this.bech32Address
     const grantType = this.isEvmWallet() ? GrantType.SignatureEth : GrantType.SignatureCosmos
     if (this.jwtAuthMode === JwtAuthMode.Legacy && !forceChallenge) {

--- a/tests/auth-session.test.cjs
+++ b/tests/auth-session.test.cjs
@@ -28,7 +28,8 @@ function token({
   tokenUse = "accessToken",
 } = {}) {
   const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
-  return `${encode({ alg, typ })}.${encode({ iss, aud, sub, iat, exp, token_use: tokenUse })}.signature`;
+  const signature = Buffer.alloc(64, 7).toString("base64url");
+  return `${encode({ alg, typ })}.${encode({ iss, aud, sub, iat, exp, token_use: tokenUse })}.${signature}`;
 }
 
 function session(overrides = {}) {
@@ -76,6 +77,11 @@ test("accepts only a strict access-token envelope for the expected wallet", () =
     token({ iat: now + 120, sub: subject }),
     token({ iat: now + 1000, exp: now + 100, sub: subject }),
     token({ exp: now - 1, sub: subject }),
+    token({ sub: subject }).split('.').slice(0, 2).join('.'),
+    `${token({ sub: subject }).split('.').slice(0, 2).join('.')}.`,
+    `${token({ sub: subject })}.extra`,
+    `${token({ sub: subject }).split('.').slice(0, 2).join('.')}.signature`,
+    `${token({ sub: subject }).split('.').slice(0, 2).join('.')}.A`,
     "malformed",
   ];
 

--- a/tests/fixtures/side-effect-audit.json
+++ b/tests/fixtures/side-effect-audit.json
@@ -2,6 +2,6 @@
   "generatedLongInitializerEntries": 416,
   "generatedLongInitializerDigest": "d9aa75514406abb563ea4c8553e88b5bbe342df30d206f6ff7523cbbae2cc0f1",
   "eagerInitializerEntries": 245,
-  "eagerInitializerDigest": "4cba65be54572be608ac5d3091fa54e1dfa70d89ec0bb4ddda8363fc028832ca",
+  "eagerInitializerDigest": "26d40ca225edd01a27d8e5270bc19d130ab38aaede3c03bc5f56b8145b45ca49",
   "rationale": "Generated protobuf modules configure protobufjs Long once at module evaluation; all 416 setup occurrences are fingerprinted exactly without file deduplication. The eager-declaration fingerprint additionally covers all reviewed variable/static/export initializers, 75 top-level enums, and 30 top-level namespaces. Both fingerprints retain source positions, duplicate occurrences, and exact runtime-significant text. Any generated initializer, eager declaration, parser diagnostic, runtime import-equals, dependency-only import/re-export, decorator, non-empty static block, or other executable top-level statement requires explicit review before the package sideEffects allowlist remains empty."
 }

--- a/tests/fixtures/side-effect-audit.json
+++ b/tests/fixtures/side-effect-audit.json
@@ -2,6 +2,6 @@
   "generatedLongInitializerEntries": 416,
   "generatedLongInitializerDigest": "d9aa75514406abb563ea4c8553e88b5bbe342df30d206f6ff7523cbbae2cc0f1",
   "eagerInitializerEntries": 245,
-  "eagerInitializerDigest": "d9fbae460629384946fd46892993d547d4df18f8fdca909b6092ae72800692c5",
+  "eagerInitializerDigest": "4cba65be54572be608ac5d3091fa54e1dfa70d89ec0bb4ddda8363fc028832ca",
   "rationale": "Generated protobuf modules configure protobufjs Long once at module evaluation; all 416 setup occurrences are fingerprinted exactly without file deduplication. The eager-declaration fingerprint additionally covers all reviewed variable/static/export initializers, 75 top-level enums, and 30 top-level namespaces. Both fingerprints retain source positions, duplicate occurrences, and exact runtime-significant text. Any generated initializer, eager declaration, parser diagnostic, runtime import-equals, dependency-only import/re-export, decorator, non-empty static block, or other executable top-level statement requires explicit review before the package sideEffects allowlist remains empty."
 }

--- a/tests/fixtures/side-effect-audit.json
+++ b/tests/fixtures/side-effect-audit.json
@@ -2,6 +2,6 @@
   "generatedLongInitializerEntries": 416,
   "generatedLongInitializerDigest": "d9aa75514406abb563ea4c8553e88b5bbe342df30d206f6ff7523cbbae2cc0f1",
   "eagerInitializerEntries": 245,
-  "eagerInitializerDigest": "15270ef9e674bc6dff80a5577d786827c1271fe0adbb5e8768b7890d0e780086",
+  "eagerInitializerDigest": "d9fbae460629384946fd46892993d547d4df18f8fdca909b6092ae72800692c5",
   "rationale": "Generated protobuf modules configure protobufjs Long once at module evaluation; all 416 setup occurrences are fingerprinted exactly without file deduplication. The eager-declaration fingerprint additionally covers all reviewed variable/static/export initializers, 75 top-level enums, and 30 top-level namespaces. Both fingerprints retain source positions, duplicate occurrences, and exact runtime-significant text. Any generated initializer, eager declaration, parser diagnostic, runtime import-equals, dependency-only import/re-export, decorator, non-empty static block, or other executable top-level statement requires explicit review before the package sideEffects allowlist remains empty."
 }

--- a/tests/http-compatible-patches.test.cjs
+++ b/tests/http-compatible-patches.test.cjs
@@ -108,11 +108,11 @@ test("follow-redirects strips credentials on a cross-host redirect", async (cont
     receivedHeaders = request.headers;
     response.end("ok");
   });
-  const targetPort = await listen(target, "localhost");
+  const targetPort = await listen(target, "127.0.0.2");
   context.after(() => close(target));
 
   const redirect = http.createServer((_request, response) => {
-    response.writeHead(302, { location: `http://localhost:${targetPort}/target` });
+    response.writeHead(302, { location: `http://127.0.0.2:${targetPort}/target` });
     response.end();
   });
   const redirectPort = await listen(redirect);

--- a/tests/wallet-challenge-auth.test.cjs
+++ b/tests/wallet-challenge-auth.test.cjs
@@ -9,16 +9,45 @@ const {
   JwtAuthMode,
   WalletAuthenticationError,
 } = require("../lib/util/auth");
+const { SWTHAddress } = require("../lib/util/address");
 const { CarbonWallet } = require("../lib/wallet/CarbonWallet");
 const { MetaMask } = require("../lib/provider/metamask/MetaMask");
 const CarbonSDK = require("../lib/CarbonSDK").default;
 
-const session = {
+const now = Math.floor(Date.now() / 1000);
+const opaqueRefreshToken = Buffer.alloc(32, 7).toString("base64url");
+
+function jwt({ subject, refresh = false }) {
+  const issuer = "demex-auth";
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  const signature = Buffer.alloc(64, 7).toString("base64url");
+  return `${encode({ alg: "ES256", typ: refresh ? "rt+jwt" : "at+jwt" })}.${encode({
+    iss: issuer,
+    aud: issuer,
+    sub: subject,
+    iat: now - 10,
+    exp: now + (refresh ? 3600 : 600),
+    token_use: refresh ? "refreshToken" : "accessToken",
+  })}.${signature}`;
+}
+
+function sessionForSubject(subject, overrides = {}) {
+  return {
+    access_token: jwt({ subject }),
+    refresh_token: opaqueRefreshToken,
+    token_type: "Bearer",
+    expires_in: 600,
+    expires_at: now + 600,
+    ...overrides,
+  };
+}
+
+const nonJwtSession = {
   access_token: "access-token",
   refresh_token: "refresh-token",
   token_type: "Bearer",
   expires_in: 600,
-  expires_at: Math.floor(Date.now() / 1000) + 600,
+  expires_at: now + 600,
 };
 
 function privateKeyWallet(mode = JwtAuthMode.Challenge) {
@@ -31,6 +60,8 @@ function privateKeyWallet(mode = JwtAuthMode.Challenge) {
   wallet.jwt = undefined;
   return wallet;
 }
+
+const session = sessionForSubject(privateKeyWallet().bech32Address);
 
 function challenge(id, message = "server-controlled exact message", walletAddress = "wallet") {
   return {
@@ -257,6 +288,7 @@ test("legacy callback errors are credential-free while the thrown Axios error re
 
 test("malformed successful redemption responses fail before completion", async () => {
   for (const malformed of [
+    nonJwtSession,
     undefined,
     { ...session, access_token: "" },
     { ...session, refresh_token: " " },
@@ -311,6 +343,7 @@ test("CarbonSDK MetaMask login requests SIWE before one signing prompt and redee
   let challengeRequests = 0;
   let redemptions = 0;
   let redeemed = false;
+  let issuedSession;
   const lifecycle = [];
   const provider = {
     legacyEip712SignMode: false,
@@ -336,7 +369,9 @@ test("CarbonSDK MetaMask login requests SIWE before one signing prompt and redee
     assert.equal(body.challenge_id, "E".repeat(43));
     assert.equal(body.message, undefined);
     redeemed = true;
-    return { data: { result: session } };
+    const subject = SWTHAddress.publicKeyToAddress(Buffer.from(body.public_key, "hex"), { network: Network.MainNet });
+    issuedSession = sessionForSubject(subject);
+    return { data: { result: issuedSession } };
   }, () => sdk.connectWithMetamask(provider, {
     enableJwtAuth: true,
     onRequestAuth: async () => { lifecycle.push("request"); },
@@ -349,7 +384,7 @@ test("CarbonSDK MetaMask login requests SIWE before one signing prompt and redee
 
   assert.deepEqual({ prompts, challengeRequests, redemptions }, { prompts: 1, challengeRequests: 1, redemptions: 1 });
   assert.deepEqual(lifecycle, ["request", "complete"]);
-  assert.equal(connected.jwt, session);
+  assert.equal(connected.jwt, issuedSession);
 });
 
 test("MetaMask legacy lifecycle is exactly once and excludes post-redemption initialization", async () => {
@@ -364,7 +399,10 @@ test("MetaMask legacy lifecycle is exactly once and excludes post-redemption ini
   const postRedemptionError = new Error("RPC initialization failed");
   sdk.connect = async () => { throw postRedemptionError; };
 
-  await assert.rejects(withAxiosPost(async () => ({ data: { result: session } }), () => sdk.connectWithMetamask(provider, {
+  await assert.rejects(withAxiosPost(async (_url, body) => {
+    const subject = SWTHAddress.publicKeyToAddress(Buffer.from(body.public_key, "hex"), { network: Network.MainNet });
+    return { data: { result: sessionForSubject(subject) } };
+  }, () => sdk.connectWithMetamask(provider, {
     enableJwtAuth: true,
     jwtAuthMode: JwtAuthMode.Legacy,
     onRequestAuth: async () => { lifecycle.push("request"); },
@@ -381,6 +419,19 @@ test("default challenge mode rejects a caller-supplied legacy signature grant", 
     public_key: "02".padEnd(66, "0"),
     signature: "00".repeat(64),
   }), (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected");
+});
+
+test("caller-supplied opaque refresh grants are rejected before posting", async () => {
+  const wallet = privateKeyWallet();
+  let posted = false;
+  await assert.rejects(withAxiosPost(async () => {
+    posted = true;
+    return { data: { result: session } };
+  }, () => wallet.reloadJwtToken({
+    grant_type: "refresh_token",
+    refresh_token: Buffer.alloc(32, 7).toString("base64url"),
+  })), (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected");
+  assert.equal(posted, false);
 });
 
 test("CarbonSDK connect preserves typed authentication failures", async () => {

--- a/tests/wallet-challenge-auth.test.cjs
+++ b/tests/wallet-challenge-auth.test.cjs
@@ -1,0 +1,289 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global Buffer, require, setTimeout, console */
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const axios = require("axios");
+const { ethers } = require("ethers");
+const { Network } = require("../lib/constant");
+const {
+  JwtAuthMode,
+  WalletAuthenticationError,
+} = require("../lib/util/auth");
+const { CarbonWallet } = require("../lib/wallet/CarbonWallet");
+const { MetaMask } = require("../lib/provider/metamask/MetaMask");
+const CarbonSDK = require("../lib/CarbonSDK").default;
+
+const session = {
+  access_token: "access-token",
+  refresh_token: "refresh-token",
+  token_type: "Bearer",
+  expires_in: 600,
+  expires_at: Math.floor(Date.now() / 1000) + 600,
+};
+
+function privateKeyWallet(mode = JwtAuthMode.Challenge) {
+  const wallet = new CarbonWallet({
+    mode: "privateKey",
+    network: Network.MainNet,
+    privateKey: Buffer.alloc(32, 7),
+    jwtAuthMode: mode,
+  });
+  wallet.jwt = undefined;
+  return wallet;
+}
+
+function challenge(id, message = "server-controlled exact message", walletAddress = "wallet") {
+  return {
+    challenge_id: id,
+    message,
+    expires_at: new Date(Date.now() + 300_000).toISOString(),
+    metadata: {
+      grant_type: "signature_cosmos",
+      wallet_address: walletAddress,
+      domain: "app.dem.exchange",
+      uri: "https://app.dem.exchange",
+      environment: "mainnet",
+      network: "mainnet",
+      chain_id: "carbon-1",
+      purpose: "wallet-login",
+    },
+  };
+}
+
+function axiosError(status, reason) {
+  const error = new Error("request failed");
+  error.isAxiosError = true;
+  error.response = { status, data: { error: { errors: { reason } } } };
+  error.config = { data: "signed-security-sensitive-body" };
+  return error;
+}
+
+async function withAxiosPost(handler, run) {
+  const original = axios.post;
+  axios.post = handler;
+  try { return await run(); } finally { axios.post = original; }
+}
+
+test("Cosmos challenge login signs only the exact server message and redeems without a client message", async () => {
+  const wallet = privateKeyWallet();
+  let signCalls = 0;
+  wallet.signer.signMessage = async (_address, message) => {
+    signCalls += 1;
+    assert.equal(message, "server-controlled exact message");
+    return "cosmos-signature";
+  };
+  const requests = [];
+
+  await withAxiosPost(async (url, body) => {
+    requests.push({ url, body });
+    if (url === wallet.networkConfig.authChallengeUrl) return { data: { result: challenge("A".repeat(43), "server-controlled exact message", wallet.bech32Address) } };
+    assert.equal(url, wallet.networkConfig.authUrl);
+    assert.deepEqual(Object.keys(body).sort(), ["challenge_id", "grant_type", "public_key", "signature"]);
+    assert.equal(body.challenge_id, "A".repeat(43));
+    assert.equal(body.grant_type, "signature_cosmos");
+    assert.equal(body.signature, "cosmos-signature");
+    return { data: { result: session } };
+  }, () => wallet.reloadJwtToken());
+
+  assert.equal(signCalls, 1);
+  assert.equal(requests.length, 2);
+  assert.equal(wallet.jwt, session);
+});
+
+test("expired challenge obtains one new challenge and signs each exact message once", async () => {
+  const wallet = privateKeyWallet();
+  const signedMessages = [];
+  wallet.signer.signMessage = async (_address, message) => {
+    signedMessages.push(message);
+    return `signature-${signedMessages.length}`;
+  };
+  let issueCount = 0;
+  let redeemCount = 0;
+
+  await withAxiosPost(async (url) => {
+    if (url === wallet.networkConfig.authChallengeUrl) {
+      issueCount += 1;
+      return { data: { result: challenge(String(issueCount).repeat(43), `message-${issueCount}`, wallet.bech32Address) } };
+    }
+    redeemCount += 1;
+    if (redeemCount === 1) throw axiosError(401, "expired");
+    return { data: { result: session } };
+  }, () => wallet.reloadJwtToken());
+
+  assert.equal(issueCount, 2);
+  assert.equal(redeemCount, 2);
+  assert.deepEqual(signedMessages, ["message-1", "message-2"]);
+});
+
+test("rejected signatures and unavailable challenge service do not retry or fall back to legacy", async () => {
+  for (const scenario of [
+    { status: 401, reason: "used", expectedCode: "challenge_rejected", expectedSigns: 1 },
+    { status: 503, reason: "challenge_store_unavailable", expectedCode: "challenge_unavailable", expectedSigns: 0 },
+  ]) {
+    const wallet = privateKeyWallet();
+    let signs = 0;
+    let challenges = 0;
+    wallet.signer.signMessage = async () => { signs += 1; return "signature"; };
+
+    await withAxiosPost(async (url) => {
+      if (url === wallet.networkConfig.authChallengeUrl) {
+        challenges += 1;
+        if (scenario.status === 503) throw axiosError(scenario.status, scenario.reason);
+        return { data: { result: challenge("B".repeat(43), "server-controlled exact message", wallet.bech32Address) } };
+      }
+      throw axiosError(scenario.status, scenario.reason);
+    }, async () => {
+      await assert.rejects(wallet.reloadJwtToken(), (error) => {
+        assert.ok(error instanceof WalletAuthenticationError);
+        assert.equal(error.code, scenario.expectedCode);
+        assert.equal(String(error).includes("signed-security-sensitive-body"), false);
+        return true;
+      });
+    });
+
+    assert.equal(challenges, 1);
+    assert.equal(signs, scenario.expectedSigns);
+  }
+});
+
+test("concurrent authentication shares one challenge, signing prompt, and redemption", async () => {
+  const wallet = privateKeyWallet();
+  let challenges = 0;
+  let signs = 0;
+  let redemptions = 0;
+  wallet.signer.signMessage = async () => { signs += 1; return "signature"; };
+
+  await withAxiosPost(async (url) => {
+    if (url === wallet.networkConfig.authChallengeUrl) {
+      challenges += 1;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return { data: { result: challenge("C".repeat(43), "server-controlled exact message", wallet.bech32Address) } };
+    }
+    redemptions += 1;
+    return { data: { result: session } };
+  }, () => Promise.all([wallet.reloadJwtToken(), wallet.reloadJwtToken(), wallet.reloadJwtToken()]));
+
+  assert.deepEqual({ challenges, signs, redemptions }, { challenges: 1, signs: 1, redemptions: 1 });
+});
+
+test("authentication callbacks bracket each real prompt and no credential is logged", async () => {
+  const wallet = privateKeyWallet();
+  const lifecycle = [];
+  wallet.onRequestAuth = async () => { lifecycle.push("request"); };
+  wallet.onAuthComplete = async () => { lifecycle.push("complete"); };
+  wallet.signer.signMessage = async () => "do-not-log-signature";
+  const output = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args) => output.push(args.join(" "));
+  console.error = (...args) => output.push(args.join(" "));
+  try {
+    await withAxiosPost(async (url) => url === wallet.networkConfig.authChallengeUrl
+      ? { data: { result: challenge("D".repeat(43), "do-not-log-message", wallet.bech32Address) } }
+      : { data: { result: session } }, () => wallet.reloadJwtToken());
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+  assert.deepEqual(lifecycle, ["request", "complete"]);
+  assert.equal(output.join("\n").includes("do-not-log"), false);
+});
+
+test("legacy timestamp login remains available only when explicitly configured", async () => {
+  const wallet = privateKeyWallet(JwtAuthMode.Legacy);
+  let signedMessage;
+  wallet.signer.signMessage = async (_address, message) => { signedMessage = message; return "legacy-signature"; };
+
+  await withAxiosPost(async (url, body) => {
+    assert.equal(url, wallet.networkConfig.authUrl);
+    assert.equal(body.challenge_id, undefined);
+    assert.match(body.message, /\[\d{4}\/\d{2}\/\d{2}/);
+    return { data: { result: session } };
+  }, () => wallet.reloadJwtToken(undefined, "Legacy statement"));
+
+  assert.match(signedMessage, /^Legacy statement\n\[/);
+});
+
+test("MetaMask public-key recovery uses one signature over a supplied server message", async () => {
+  const signingWallet = ethers.Wallet.createRandom();
+  let prompts = 0;
+  const provider = {
+    defaultAccount: async () => signingWallet.address,
+    personalSign: async (_address, message) => {
+      prompts += 1;
+      return signingWallet.signMessage(message);
+    },
+  };
+  const result = await MetaMask.signAndRecoverPubKeyForMessage(provider, "exact SIWE message");
+  assert.equal(prompts, 1);
+  assert.equal(result.message, "exact SIWE message");
+  assert.equal(typeof result.publicKey, "string");
+  assert.equal(typeof result.signature, "string");
+});
+
+test("CarbonSDK MetaMask login requests SIWE before one signing prompt and redeems that credential", async () => {
+  const signingWallet = ethers.Wallet.createRandom();
+  let prompts = 0;
+  let challengeRequests = 0;
+  let redemptions = 0;
+  const provider = {
+    legacyEip712SignMode: false,
+    defaultAccount: async () => signingWallet.address,
+    personalSign: async (_address, message) => {
+      prompts += 1;
+      assert.equal(message, "server SIWE message");
+      return signingWallet.signMessage(message);
+    },
+  };
+  const sdk = new CarbonSDK({ network: Network.MainNet });
+  sdk.connect = async (wallet) => wallet;
+
+  const connected = await withAxiosPost(async (url, body) => {
+    if (url === sdk.networkConfig.authChallengeUrl) {
+      challengeRequests += 1;
+      assert.deepEqual(body, { grant_type: "signature_eth", wallet_address: signingWallet.address });
+      const value = challenge("E".repeat(43), "server SIWE message", signingWallet.address);
+      value.metadata.grant_type = "signature_eth";
+      return { data: { result: value } };
+    }
+    redemptions += 1;
+    assert.equal(body.challenge_id, "E".repeat(43));
+    assert.equal(body.message, undefined);
+    return { data: { result: session } };
+  }, () => sdk.connectWithMetamask(provider, { enableJwtAuth: true }));
+
+  assert.deepEqual({ prompts, challengeRequests, redemptions }, { prompts: 1, challengeRequests: 1, redemptions: 1 });
+  assert.equal(connected.jwt, session);
+});
+
+test("default challenge mode rejects a caller-supplied legacy signature grant", async () => {
+  const wallet = privateKeyWallet();
+  await assert.rejects(wallet.reloadJwtToken({
+    grant_type: "signature_cosmos",
+    message: "caller controlled",
+    public_key: "02".padEnd(66, "0"),
+    signature: "00".repeat(64),
+  }), (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected");
+});
+
+test("CarbonSDK connect preserves typed authentication failures", async () => {
+  const sdk = new CarbonSDK({ network: Network.MainNet });
+  const expected = new WalletAuthenticationError("challenge_unavailable", 503);
+  sdk.getGasFee = async () => ({});
+  const wallet = {
+    initialized: false,
+    initialize: async () => { throw expected; },
+  };
+  await assert.rejects(sdk.connect(wallet), (error) => error === expected && error.code === "challenge_unavailable");
+});
+
+test("malformed successful challenge responses fail with a stable sanitized error before signing", async () => {
+  const wallet = privateKeyWallet();
+  let signs = 0;
+  wallet.signer.signMessage = async () => { signs += 1; return "signature"; };
+  const malformed = challenge("F".repeat(43), "message", wallet.bech32Address);
+  malformed.metadata.wallet_address = 42;
+  await assert.rejects(withAxiosPost(async () => ({ data: { result: malformed } }), () => wallet.reloadJwtToken()),
+    (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected");
+  assert.equal(signs, 0);
+});

--- a/tests/wallet-challenge-auth.test.cjs
+++ b/tests/wallet-challenge-auth.test.cjs
@@ -191,6 +191,9 @@ test("authentication callbacks bracket each real prompt and no credential is log
 
 test("legacy timestamp login remains available only when explicitly configured", async () => {
   const wallet = privateKeyWallet(JwtAuthMode.Legacy);
+  const lifecycle = [];
+  wallet.onRequestAuth = async () => { lifecycle.push("request"); };
+  wallet.onAuthComplete = async (error) => { lifecycle.push(error ? "error" : "complete"); };
   let signedMessage;
   wallet.signer.signMessage = async (_address, message) => { signedMessage = message; return "legacy-signature"; };
 
@@ -202,6 +205,64 @@ test("legacy timestamp login remains available only when explicitly configured",
   }, () => wallet.reloadJwtToken(undefined, "Legacy statement"));
 
   assert.match(signedMessage, /^Legacy statement\n\[/);
+  assert.deepEqual(lifecycle, ["request", "complete"]);
+});
+
+test("callback failures never duplicate completion or replace authentication results", async () => {
+  const successful = privateKeyWallet();
+  let successCallbacks = 0;
+  successful.onAuthComplete = async () => {
+    successCallbacks += 1;
+    throw new Error("UI callback failed");
+  };
+  await withAxiosPost(async (url) => url === successful.networkConfig.authChallengeUrl
+    ? { data: { result: challenge("J".repeat(43), "server message", successful.bech32Address) } }
+    : { data: { result: session } }, () => successful.reloadJwtToken());
+  assert.equal(successCallbacks, 1);
+  assert.equal(successful.jwt, session);
+
+  const rejected = privateKeyWallet();
+  let failureCallbacks = 0;
+  rejected.onAuthComplete = async () => {
+    failureCallbacks += 1;
+    throw new Error("UI callback failed");
+  };
+  await assert.rejects(
+    withAxiosPost(async () => ({ data: null }), () => rejected.reloadJwtToken()),
+    (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected",
+  );
+  assert.equal(failureCallbacks, 1);
+});
+
+test("legacy callback errors are credential-free while the thrown Axios error remains compatible", async () => {
+  const wallet = privateKeyWallet(JwtAuthMode.Legacy);
+  const axiosError = Object.assign(new Error("legacy redemption failed"), {
+    config: { data: JSON.stringify({ message: "signed-message", signature: "signed-credential" }) },
+  });
+  let callbackError;
+  wallet.onAuthComplete = async (error) => { callbackError = error; };
+
+  await assert.rejects(
+    withAxiosPost(async () => { throw axiosError; }, () => wallet.reloadJwtToken()),
+    (error) => error === axiosError,
+  );
+  assert.equal(callbackError?.message, "Wallet authentication failed.");
+  assert.equal("config" in callbackError, false);
+  assert.equal(JSON.stringify(callbackError).includes("signed-credential"), false);
+});
+
+test("malformed successful redemption responses fail before completion", async () => {
+  const wallet = privateKeyWallet();
+  const lifecycle = [];
+  wallet.onRequestAuth = async () => { lifecycle.push("request"); };
+  wallet.onAuthComplete = async (error) => { lifecycle.push(error?.code ?? "complete"); };
+
+  await assert.rejects(withAxiosPost(async (url) => url === wallet.networkConfig.authChallengeUrl
+    ? { data: { result: challenge("K".repeat(43), "server message", wallet.bech32Address) } }
+    : { data: {} }, () => wallet.reloadJwtToken()),
+  (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected");
+  assert.deepEqual(lifecycle, ["request", "challenge_rejected"]);
+  assert.equal(wallet.jwt, undefined);
 });
 
 test("MetaMask public-key recovery uses one signature over a supplied server message", async () => {
@@ -226,6 +287,8 @@ test("CarbonSDK MetaMask login requests SIWE before one signing prompt and redee
   let prompts = 0;
   let challengeRequests = 0;
   let redemptions = 0;
+  let redeemed = false;
+  const lifecycle = [];
   const provider = {
     legacyEip712SignMode: false,
     defaultAccount: async () => signingWallet.address,
@@ -249,11 +312,42 @@ test("CarbonSDK MetaMask login requests SIWE before one signing prompt and redee
     redemptions += 1;
     assert.equal(body.challenge_id, "E".repeat(43));
     assert.equal(body.message, undefined);
+    redeemed = true;
     return { data: { result: session } };
-  }, () => sdk.connectWithMetamask(provider, { enableJwtAuth: true }));
+  }, () => sdk.connectWithMetamask(provider, {
+    enableJwtAuth: true,
+    onRequestAuth: async () => { lifecycle.push("request"); },
+    onAuthComplete: async (error) => {
+      assert.equal(error, undefined);
+      assert.equal(redeemed, true);
+      lifecycle.push("complete");
+    },
+  }));
 
   assert.deepEqual({ prompts, challengeRequests, redemptions }, { prompts: 1, challengeRequests: 1, redemptions: 1 });
+  assert.deepEqual(lifecycle, ["request", "complete"]);
   assert.equal(connected.jwt, session);
+});
+
+test("MetaMask legacy lifecycle is exactly once and excludes post-redemption initialization", async () => {
+  const signingWallet = ethers.Wallet.createRandom();
+  const provider = {
+    legacyEip712SignMode: false,
+    defaultAccount: async () => signingWallet.address,
+    personalSign: async (_address, message) => signingWallet.signMessage(message),
+  };
+  const sdk = new CarbonSDK({ network: Network.MainNet });
+  const lifecycle = [];
+  const postRedemptionError = new Error("RPC initialization failed");
+  sdk.connect = async () => { throw postRedemptionError; };
+
+  await assert.rejects(withAxiosPost(async () => ({ data: { result: session } }), () => sdk.connectWithMetamask(provider, {
+    enableJwtAuth: true,
+    jwtAuthMode: JwtAuthMode.Legacy,
+    onRequestAuth: async () => { lifecycle.push("request"); },
+    onAuthComplete: async (error) => { lifecycle.push(error ? "error" : "complete"); },
+  })), (error) => error === postRedemptionError);
+  assert.deepEqual(lifecycle, ["request", "complete"]);
 });
 
 test("default challenge mode rejects a caller-supplied legacy signature grant", async () => {
@@ -286,4 +380,30 @@ test("malformed successful challenge responses fail with a stable sanitized erro
   await assert.rejects(withAxiosPost(async () => ({ data: { result: malformed } }), () => wallet.reloadJwtToken()),
     (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected");
   assert.equal(signs, 0);
+});
+
+test("null successful challenge bodies are typed rejections for Cosmos and MetaMask", async () => {
+  const wallet = privateKeyWallet();
+  const lifecycle = [];
+  wallet.onAuthComplete = async (error) => { lifecycle.push(error?.code); };
+  await assert.rejects(
+    withAxiosPost(async () => ({ data: null }), () => wallet.reloadJwtToken()),
+    (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected",
+  );
+  assert.deepEqual(lifecycle, ["challenge_rejected"]);
+
+  const sdk = new CarbonSDK({ network: Network.MainNet });
+  const provider = {
+    defaultAccount: async () => ethers.Wallet.createRandom().address,
+    personalSign: async () => { throw new Error("must not sign"); },
+  };
+  const evmLifecycle = [];
+  await assert.rejects(
+    withAxiosPost(async () => ({ data: null }), () => sdk.connectWithMetamask(provider, {
+      enableJwtAuth: true,
+      onAuthComplete: async (error) => { evmLifecycle.push(error?.code); },
+    })),
+    (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected",
+  );
+  assert.deepEqual(evmLifecycle, ["challenge_rejected"]);
 });

--- a/tests/wallet-challenge-auth.test.cjs
+++ b/tests/wallet-challenge-auth.test.cjs
@@ -92,6 +92,9 @@ test("Cosmos challenge login signs only the exact server message and redeems wit
 
 test("expired challenge obtains one new challenge and signs each exact message once", async () => {
   const wallet = privateKeyWallet();
+  const lifecycle = [];
+  wallet.onRequestAuth = async () => { lifecycle.push("request"); };
+  wallet.onAuthComplete = async () => { lifecycle.push("complete"); };
   const signedMessages = [];
   wallet.signer.signMessage = async (_address, message) => {
     signedMessages.push(message);
@@ -113,6 +116,7 @@ test("expired challenge obtains one new challenge and signs each exact message o
   assert.equal(issueCount, 2);
   assert.equal(redeemCount, 2);
   assert.deepEqual(signedMessages, ["message-1", "message-2"]);
+  assert.deepEqual(lifecycle, ["request", "complete"]);
 });
 
 test("rejected signatures and unavailable challenge service do not retry or fall back to legacy", async () => {
@@ -252,17 +256,36 @@ test("legacy callback errors are credential-free while the thrown Axios error re
 });
 
 test("malformed successful redemption responses fail before completion", async () => {
-  const wallet = privateKeyWallet();
-  const lifecycle = [];
-  wallet.onRequestAuth = async () => { lifecycle.push("request"); };
-  wallet.onAuthComplete = async (error) => { lifecycle.push(error?.code ?? "complete"); };
+  for (const malformed of [
+    undefined,
+    { ...session, access_token: "" },
+    { ...session, refresh_token: " " },
+    { ...session, expires_in: 0 },
+    { ...session, expires_at: Number.POSITIVE_INFINITY },
+  ]) {
+    const wallet = privateKeyWallet();
+    const lifecycle = [];
+    wallet.onRequestAuth = async () => { lifecycle.push("request"); };
+    wallet.onAuthComplete = async (error) => { lifecycle.push(error?.code ?? "complete"); };
 
-  await assert.rejects(withAxiosPost(async (url) => url === wallet.networkConfig.authChallengeUrl
-    ? { data: { result: challenge("K".repeat(43), "server message", wallet.bech32Address) } }
-    : { data: {} }, () => wallet.reloadJwtToken()),
-  (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected");
-  assert.deepEqual(lifecycle, ["request", "challenge_rejected"]);
-  assert.equal(wallet.jwt, undefined);
+    await assert.rejects(withAxiosPost(async (url) => url === wallet.networkConfig.authChallengeUrl
+      ? { data: { result: challenge("K".repeat(43), "server message", wallet.bech32Address) } }
+      : { data: { result: malformed } }, () => wallet.reloadJwtToken()),
+    (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected");
+    assert.deepEqual(lifecycle, ["request", "challenge_rejected"]);
+    assert.equal(wallet.jwt, undefined);
+  }
+});
+
+test("malformed successful refresh responses are rejected without assigning session state", async () => {
+  for (const malformed of [undefined, {}, { ...session, access_token: "" }, { ...session, expires_in: -1 }]) {
+    const wallet = privateKeyWallet();
+    await assert.rejects(
+      withAxiosPost(async () => ({ data: { result: malformed } }), () => wallet.refreshJwtToken("refresh-token")),
+      /invalid token response/,
+    );
+    assert.equal(wallet.jwt, undefined);
+  }
 });
 
 test("MetaMask public-key recovery uses one signature over a supplied server message", async () => {


### PR DESCRIPTION
Companion to Switcheo/demex-auth#18 and Switcheo/demex-auth#12.

## Summary
- make server-issued challenge authentication the SDK default for Cosmos, MetaMask, and RainbowKit wallets
- sign the exact server message and redeem only `challenge_id`, public key, and signature
- preserve access-token caching, refresh behavior, and token response handling
- coalesce concurrent authentication into one challenge, one wallet prompt, and one redemption
- retry an explicitly expired challenge once with a newly issued challenge; never retry the same signed challenge
- retain timestamp login only behind explicit `jwtAuthMode: legacy` configuration, with no automatic fallback
- preserve typed and sanitized authentication errors through `CarbonSDK.connect`
- isolate signing/redemption lifecycle callbacks from post-auth RPC initialization and prevent callback telemetry from receiving signed legacy credentials

## Security / compatibility
- challenge response metadata is validated before signing
- default challenge mode rejects caller-supplied legacy grants
- EVM identity is recovered from the exact EIP-191 message/signature
- clients never reconstruct or submit the server message during redemption
- refresh request and public JWT response behavior are unchanged

## Validation
- Node 24.18.0 / Yarn 1 build and ESLint: pass
- full SDK suite: 210/210 pass
- challenge-focused suite: 17/17 pass, including malformed refresh/redemption, callback isolation, expired-challenge lifecycle cardinality, explicit legacy lifecycle, and post-redemption initialization boundaries
- deterministic cross-host redirect harness: 5 consecutive 7/7 passes
- side-effect audit: pass with zero violations
- packed artifact SHA-256: `216698ba218f7a447cd96879c734040e9c4acbed563a67cbf893662cb06ab432`
- exact artifact installed and loaded in a clean Node 24 consumer
- Disco auth/Dagger contracts: 30/30 pass; TypeScript and ESLint pass
- live cross-service Cosmos/EVM login, refresh, JWT verification, cross-environment, and replay tests: pass

No package version bump, tag, release, registry publication, merge, or deployment is included.
