### PR TITLE
fix: validate ES256 session signatures and release 0.11.78

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-js-sdk",
-  "version": "0.11.77",
+  "version": "0.11.78",
   "description": "TypeScript SDK for Carbon blockchain",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/src/util/auth.ts
+++ b/src/util/auth.ts
@@ -207,6 +207,10 @@ const isCanonicalBase64UrlSegment = (segment: string): boolean => {
   return remainder === 2 ? finalSextet % 16 === 0 : finalSextet % 4 === 0
 }
 
+function decodedBase64UrlByteLength(segment: string): number {
+  return Math.floor(segment.length * 6 / 8)
+}
+
 /**
  * Checks whether an unverified JWT envelope is suitable for local session reuse.
  * Resource servers remain responsible for signature verification and authorization.
@@ -221,7 +225,9 @@ const isJwtSessionTokenUsable = (
   if (typeof token !== 'string' || token.length === 0
     || typeof expectedSubject !== 'string' || expectedSubject.length === 0) return false
   const segments = token.split('.')
-  if (segments.length !== 3 || segments.some((segment) => !isCanonicalBase64UrlSegment(segment))) return false
+  if (segments.length !== 3
+    || segments.some((segment) => !isCanonicalBase64UrlSegment(segment))
+    || decodedBase64UrlByteLength(segments[2]) !== 64) return false
 
   try {
     const header = jwtDecode<SessionTokenHeader>(token, { header: true })

--- a/tests/auth-session.test.cjs
+++ b/tests/auth-session.test.cjs
@@ -26,9 +26,10 @@ function token({
   iat = now - 10,
   exp = now + 600,
   tokenUse = "accessToken",
+  signatureBytes = 64,
 } = {}) {
   const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
-  const signature = Buffer.alloc(64, 7).toString("base64url");
+  const signature = Buffer.alloc(signatureBytes, 7).toString("base64url");
   return `${encode({ alg, typ })}.${encode({ iss, aud, sub, iat, exp, token_use: tokenUse })}.${signature}`;
 }
 
@@ -90,6 +91,18 @@ test("accepts only a strict access-token envelope for the expected wallet", () =
       isSessionTokenUsable(candidate, Network.MainNet, JWT_ACCESS_TOKEN_USE, subject),
       false,
       `expected token to be unsuitable: ${candidate}`,
+    );
+  }
+});
+
+test("requires the ES256 signature segment to contain exactly 64 raw bytes", () => {
+  const subject = "carbon-subject";
+  assert.equal(isSessionTokenUsable(token({ sub: subject, signatureBytes: 64 }), Network.MainNet, JWT_ACCESS_TOKEN_USE, subject), true);
+  for (const signatureBytes of [1, 63, 65]) {
+    assert.equal(
+      isSessionTokenUsable(token({ sub: subject, signatureBytes }), Network.MainNet, JWT_ACCESS_TOKEN_USE, subject),
+      false,
+      `expected ${signatureBytes}-byte ES256 signature to be rejected`,
     );
   }
 });

--- a/tests/wallet-challenge-auth.test.cjs
+++ b/tests/wallet-challenge-auth.test.cjs
@@ -17,10 +17,10 @@ const CarbonSDK = require("../lib/CarbonSDK").default;
 const now = Math.floor(Date.now() / 1000);
 const opaqueRefreshToken = Buffer.alloc(32, 7).toString("base64url");
 
-function jwt({ subject, refresh = false }) {
+function jwt({ subject, refresh = false, signatureBytes = 64 }) {
   const issuer = "demex-auth";
   const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
-  const signature = Buffer.alloc(64, 7).toString("base64url");
+  const signature = Buffer.alloc(signatureBytes, 7).toString("base64url");
   return `${encode({ alg: "ES256", typ: refresh ? "rt+jwt" : "at+jwt" })}.${encode({
     iss: issuer,
     aud: issuer,
@@ -290,6 +290,9 @@ test("malformed successful redemption responses fail before completion", async (
   for (const malformed of [
     nonJwtSession,
     undefined,
+    sessionForSubject(privateKeyWallet().bech32Address, {
+      access_token: jwt({ subject: privateKeyWallet().bech32Address, signatureBytes: 1 }),
+    }),
     { ...session, access_token: "" },
     { ...session, refresh_token: " " },
     { ...session, expires_in: 0 },


### PR DESCRIPTION
## What changed
- Require canonical ES256 JWT envelopes to carry the mandatory 64-byte raw `R || S` signature before they can be reused or assigned, closing the final post-#675 review finding.
- Add regressions for 1-, 63-, and 65-byte signatures and prove malformed challenge redemptions fail before session assignment or success callbacks.
- Bump the package version to `0.11.78` so the merged commit can be released as an immutable GitHub package asset.

## Validation
- Node 24.18.0 frozen install
- build and ESLint
- 214/214 tests
- package/entrypoint and release-publisher contracts
- side-effect audit: 245 entries, zero violations
- `git diff --check`

## Release
After this PR is squash-merged, tag its exact landed commit as `v0.11.78`. The existing workflow publishes a GitHub Release tarball and checksum; it does not publish to npm.