### PR TITLE
fix: accept OAuth bearer token type case-insensitively

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-js-sdk",
-  "version": "0.11.79",
+  "version": "0.11.80",
   "description": "TypeScript SDK for Carbon blockchain",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/src/wallet/CarbonWallet.ts
+++ b/src/wallet/CarbonWallet.ts
@@ -416,7 +416,8 @@ export class CarbonWallet {
       || typeof token !== 'object'
       || typeof token.access_token !== 'string'
       || !isSessionTokenUsable(token.access_token, this.network, JWT_ACCESS_TOKEN_USE, this.bech32Address)
-      || token.token_type !== 'Bearer'
+      || typeof token.token_type !== 'string'
+      || token.token_type.toLowerCase() !== 'bearer'
       || !Number.isSafeInteger(token.expires_in)
       || (token.expires_in as number) <= 0
       || !Number.isSafeInteger(token.expires_at)
@@ -432,7 +433,11 @@ export class CarbonWallet {
       if (challengeGrant) throw new AuthUtils.WalletAuthenticationError('challenge_rejected')
       throw new Error('Wallet authentication returned an invalid token response.')
     }
-    return token as AccessTokenResponse
+    if (token.token_type === 'Bearer') return token as AccessTokenResponse
+    return {
+      ...(token as AccessTokenResponse),
+      token_type: 'Bearer',
+    }
   }
 
   private async getNewJwtToken(authMessage: string, request?: GrantRequest) {

--- a/tests/fixtures/side-effect-audit.json
+++ b/tests/fixtures/side-effect-audit.json
@@ -2,6 +2,6 @@
   "generatedLongInitializerEntries": 416,
   "generatedLongInitializerDigest": "d9aa75514406abb563ea4c8553e88b5bbe342df30d206f6ff7523cbbae2cc0f1",
   "eagerInitializerEntries": 245,
-  "eagerInitializerDigest": "26d40ca225edd01a27d8e5270bc19d130ab38aaede3c03bc5f56b8145b45ca49",
+  "eagerInitializerDigest": "475d46167163bad7130e6038f85a0b1fd49562259a1c356baccfc5a3f0c34132",
   "rationale": "Generated protobuf modules configure protobufjs Long once at module evaluation; all 416 setup occurrences are fingerprinted exactly without file deduplication. The eager-declaration fingerprint additionally covers all reviewed variable/static/export initializers, 75 top-level enums, and 30 top-level namespaces. Both fingerprints retain source positions, duplicate occurrences, and exact runtime-significant text. Any generated initializer, eager declaration, parser diagnostic, runtime import-equals, dependency-only import/re-export, decorator, non-empty static block, or other executable top-level statement requires explicit review before the package sideEffects allowlist remains empty."
 }

--- a/tests/wallet-challenge-auth.test.cjs
+++ b/tests/wallet-challenge-auth.test.cjs
@@ -323,6 +323,67 @@ test("malformed successful refresh responses are rejected without assigning sess
   }
 });
 
+for (const tokenType of ["bearer", "Bearer", "bEaReR"]) {
+  test(`challenge grant accepts ${tokenType} token type and stores canonical Bearer`, async () => {
+    const wallet = privateKeyWallet();
+    const issuedSession = sessionForSubject(wallet.bech32Address, { token_type: tokenType });
+
+    await withAxiosPost(async (url) => url === wallet.networkConfig.authChallengeUrl
+      ? { data: { result: challenge("T".repeat(43), "server message", wallet.bech32Address) } }
+      : { data: { result: issuedSession } }, () => wallet.reloadJwtToken());
+
+    assert.equal(wallet.jwt.token_type, "Bearer");
+  });
+
+  test(`refresh grant accepts ${tokenType} token type and stores canonical Bearer`, async () => {
+    const wallet = privateKeyWallet();
+    const issuedSession = sessionForSubject(wallet.bech32Address, { token_type: tokenType });
+
+    await withAxiosPost(async () => ({ data: { result: issuedSession } }),
+      () => wallet.refreshJwtToken("refresh-token"));
+
+    assert.equal(wallet.jwt.token_type, "Bearer");
+  });
+}
+
+const invalidTokenTypes = [
+  ["missing", Symbol("missing")],
+  ["non-string", 42],
+  ["unsupported", "MAC"],
+];
+
+function sessionWithTokenType(subject, tokenType) {
+  const issuedSession = sessionForSubject(subject);
+  if (typeof tokenType === "symbol") delete issuedSession.token_type;
+  else issuedSession.token_type = tokenType;
+  return issuedSession;
+}
+
+for (const [description, tokenType] of invalidTokenTypes) {
+  test(`challenge grant rejects ${description} token type`, async () => {
+    const wallet = privateKeyWallet();
+    const issuedSession = sessionWithTokenType(wallet.bech32Address, tokenType);
+
+    await assert.rejects(withAxiosPost(async (url) => url === wallet.networkConfig.authChallengeUrl
+      ? { data: { result: challenge("U".repeat(43), "server message", wallet.bech32Address) } }
+      : { data: { result: issuedSession } }, () => wallet.reloadJwtToken()),
+    (error) => error instanceof WalletAuthenticationError && error.code === "challenge_rejected");
+    assert.equal(wallet.jwt, undefined);
+  });
+
+  test(`refresh grant rejects ${description} token type`, async () => {
+    const wallet = privateKeyWallet();
+    const issuedSession = sessionWithTokenType(wallet.bech32Address, tokenType);
+
+    await assert.rejects(
+      withAxiosPost(async () => ({ data: { result: issuedSession } }),
+        () => wallet.refreshJwtToken("refresh-token")),
+      /invalid token response/,
+    );
+    assert.equal(wallet.jwt, undefined);
+  });
+}
+
 test("MetaMask public-key recovery uses one signature over a supplied server message", async () => {
   const signingWallet = ethers.Wallet.createRandom();
   let prompts = 0;


### PR DESCRIPTION
## What changed
- Accept `Bearer` token types case-insensitively because OAuth 2.0 defines `token_type` as case-insensitive and Demex Auth returns lowercase `bearer`.
- Normalize accepted non-canonical values to `Bearer` before storing or returning sessions, while preserving canonical response identity.
- Cover challenge and refresh grants for lowercase, canonical, mixed-case, missing, non-string, and unsupported values.
- Bump the SDK to `0.11.80` for the canonical tag-triggered release flow.

## Verification
- Node 24.18.0 build and lint
- 227/227 tests
- side-effect audit: zero violations
- release package validator passed
- `git diff --check`
