### PR TITLE
chore(deps): consolidate verified safe dependency updates

### DIFF
--- a/.github/workflows/node24.yml
+++ b/.github/workflows/node24.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout exact publisher
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout exact tagged commit
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@eslint/js": "^9.39.5",
     "@rollup/plugin-commonjs": "29.0.3",
     "@rollup/plugin-node-resolve": "16.0.3",
-    "@types/crypto-js": "4.0.1",
+    "@types/crypto-js": "4.2.2",
     "@types/lodash": "^4.14.174",
     "@types/node": "^24.13.3",
     "@types/node-fetch": "^2.5.12",

--- a/tests/dependency-pruning.test.cjs
+++ b/tests/dependency-pruning.test.cjs
@@ -56,7 +56,7 @@ for (const [packageName, expectedVersion] of Object.entries(requiredRuntimeContr
 }
 
 test("@types/crypto-js is the exact direct development type contract", () => {
-  assert.equal(manifest.devDependencies["@types/crypto-js"], "4.0.1");
+  assert.equal(manifest.devDependencies["@types/crypto-js"], "4.2.2");
   assert.doesNotThrow(() => require.resolve("@types/crypto-js/package.json"));
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1120,10 +1120,10 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
-"@types/crypto-js@4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.0.1.tgz#3a4bd24518b0e6c5940da4e2659eeb2ef0806963"
-  integrity sha512-6+OPzqhKX/cx5xh+yO8Cqg3u3alrkhoxhE5ZOdSEv0DOzJ13lwJ6laqGU0Kv6+XDMFmlnGId04LtY22PsFLQUw==
+"@types/crypto-js@4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.2.2.tgz#771c4a768d94eb5922cc202a3009558204df0cea"
+  integrity sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==
 
 "@types/debug@^4.1.7":
   version "4.1.13"
@@ -1142,12 +1142,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/lodash@^4.14.174":
-  version "4.14.174"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.174.tgz#b4b06b6eced9850eed6b6a8f1abdd0f5192803c1"
-  integrity sha512-KMBLT6+g9qrGXpDt7ohjWPUD34WA/jasrtjTEHStF0NPdEwJ1N9SZ+4GaMVDeuk/y0+X5j9xFm6mNiXS7UoaLQ==
-
-"@types/lodash@^4.17.20":
+"@types/lodash@^4.14.174", "@types/lodash@^4.17.20":
   version "4.17.24"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.24.tgz#4ae334fc62c0e915ca8ed8e35dcc6d4eeb29215f"
   integrity sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==
@@ -1198,19 +1193,19 @@
   integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
 
 "@types/semver@^7.3.13":
-  version "7.3.13"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
-  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.1.tgz#3ce3af1a5524ef327d2da9e4fd8b6d95c8d70528"
+  integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
 
 "@types/w3c-web-hid@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@types/w3c-web-hid/-/w3c-web-hid-1.0.2.tgz#bdf2f813ffa7ccd1ca63aa218d680edddd839417"
-  integrity sha512-tNLnl6+/AkmASEnviwdLLE6kaXlY28cDVyQ3e+WwnEAm5DHyO7c71a5TtYX6ofrnzzdQSnNsjNMoggsbrtOYfQ==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@types/w3c-web-hid/-/w3c-web-hid-1.0.7.tgz#eeec7d5237b53429f20dd7a858c1b65170c9ea35"
+  integrity sha512-/y97wBH7fYB5vKoDIn11O1ZDMNFLCAVqZ9af0OWDN7VSO2ClErEN2HlGbBuPgHBTUmZOVx1og2ZHX1U2gEJM4Q==
 
 "@types/w3c-web-usb@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@types/w3c-web-usb/-/w3c-web-usb-1.0.5.tgz#90284d17f35de981670c85d29053ae8b88fa5543"
-  integrity sha512-dYolx2XWesl1TMu+1BjtjU6eC6c2zZ2VDKhjU4f/mtR3+UBfMW6h1tPCQt7leY5Y8JBg0Fe/mMnoDMkPPNX9sw==
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz#9b2c8e723045e7bf8018d47efe1b736815b23b38"
+  integrity sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==
 
 "@types/wif@^2.0.2":
   version "2.0.2"
@@ -2236,9 +2231,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.3.tgz#f695a40f006aba505631573a0021ddb21194ad11"
-  integrity sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fastq@^1.6.0:
   version "1.11.0"


### PR DESCRIPTION
## Summary

Consolidates the dependency updates that passed compatibility, supply-chain, and exact-staged review:

- `actions/checkout` `7.0.0` → `7.0.1`, pinned to exact commit `3d3c42e5aac5ba805825da76410c181273ba90b1`
- transitive development dependency `fast-uri` `3.1.3` → `3.1.4`
- declaration-only development updates:
  - `@types/crypto-js` `4.0.1` → `4.2.2`
  - `@types/lodash` `4.14.174` → `4.17.24`
  - `@types/semver` `7.3.13` → `7.7.1`
  - `@types/w3c-web-hid` `1.0.2` → `1.0.7`
  - `@types/w3c-web-usb` `1.0.5` → `1.0.14`
- refreshes the exact `@types/crypto-js` dependency contract test

Supersedes the safe portions of #663, #680, and #682. The incompatible or insufficiently exercised updates in #662, #664, #665, and #683 are deliberately excluded.

## Security and supply-chain review

- `fast-uri@3.1.4` removes the open high-severity transitive development alert.
- Its registry SHA-1/SHA-512 values match the lockfile, and all 34 published package files are byte-identical to signed upstream tag `v3.1.4`.
- `fast-uri` adds no dependencies, native code, or install lifecycle hooks.
- All five `@types` tarballs match their staged integrity values and contain no install lifecycle hooks or runtime dependencies.
- All three `actions/checkout` uses remain immutable full-SHA pins; the target commit is GitHub-verified and keeps the Node 24 runtime.
- Independent exact-staged review found no security, supply-chain, logic, or scope concerns.

## Validation

Run with the repository-declared Node `24.18.0` and Yarn `1.22.22`:

- frozen install with lifecycle scripts disabled
- dependency integrity check
- clean normal frozen install
- `yarn lint`
- `yarn check:generated`
- `yarn audit:side-effects`
- `yarn test` — 227/227 passed
- `yarn build`
- packed-consumer compatibility tests
- `npm pack --dry-run` — 2,014 packaged files

Dependabot projection: 2 open alerts (high `fast-uri`, low `elliptic`) → 1 projected open alert (low `elliptic`), with zero unevaluable alerts.

## Deliberately excluded

- CosmJS `0.38.1` → `0.39.0`: coordinated zero-major migration with current compile failures
- `bech32` `1.1.4` → `2.0.0`: breaking export-shape change and failing CI
- `bignumber.js` `9.1.2` → `11.1.5`: breaking TypeScript/import contracts and failing CI
- `actions/upload-artifact` `4.6.2` → `7.0.1`: three-major jump whose tag-triggered release upload path is not exercised by PR CI
