### PR TITLE
chore: bump package version to 0.11.81

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-js-sdk",
-  "version": "0.11.80",
+  "version": "0.11.81",
   "description": "TypeScript SDK for Carbon blockchain",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
## Summary

Bumps `carbon-js-sdk` from `0.11.80` to `0.11.81` for a new immutable GitHub Release containing the verified dependency consolidation and Carbon v2.82.0 codec update.

## Why

`v0.11.80` already exists and points to `15e61862cf0740774221bf8d9faec2d6389221f2`. The active version-tag ruleset prevents moving or reusing it, and the release workflow requires the tag to match `package.json` exactly.

After this PR merges and the merged `staging` commit passes CI, that exact commit will be tagged once as `v0.11.81`. The tag-triggered workflow will build, validate, checksum, and publish the GitHub Release package assets. Nothing will be published to npm.

## Scope

- `package.json`: `0.11.80` → `0.11.81`
- No changelog or generated-file edits

## Local verification

- Node `24.18.0`; Yarn `1.22.22`
- Script-disabled and normal frozen installs: passed
- Dependency integrity: passed with the repository's audited override boundaries
- Lint: passed
- Deterministic generated-output check: passed
- Package side-effect audit: passed
- Full test/build suite: passed
- Two `npm pack --ignore-scripts` runs were byte-identical
- Local package SHA-256: `8af342ff7df9850d1e78580a4fa08e46d262c036a03b2294a4b81f78f9b95091`
- Release package validator: 25 required files, including eight JSON assets in both builds

The published workflow artifact will have its own authoritative CI-generated checksum.
