### PR TITLE
chore: bump version to 0.11.82

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-js-sdk",
-  "version": "0.11.81",
+  "version": "0.11.82",
   "description": "TypeScript SDK for Carbon blockchain",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
## What changed

- bump the package version from `0.11.81` to `0.11.82` so the already merged CosmJS migration and audited safe dependency consolidation can be released under a new immutable tag
- leave generated files and `CHANGELOG.md` untouched because this repository forms release assets from the exact package tree and does not maintain the generated changelog manually

## Release scope

This release includes:

- #687: CosmJS 0.39 migration with Keplr/Leap direct-sign response normalization
- #690: audited compatible runtime and development dependency updates

It does not include the deferred incompatible `bech32` 2 or `bignumber.js` 11 updates, or the un-canary-tested `actions/upload-artifact` 7 major update.

## Validation

Node 24.18.0 and Yarn 1.22.22:

- script-disabled and normal frozen installs
- dependency integrity checks
- lint, generated-output verification, and side-effect audit
- 232/232 tests
- CJS and native ESM builds
- two release-style archives were byte-identical
- candidate archive SHA-256: `9459f0a501315b04bb78469ea3bb4719831fe8b4742a8f063156ada44c0dc709`
- package validator: 2,014 files, 25 required files, and eight JSON assets in both builds
- post-merge staging CI for #690: https://github.com/Switcheo/carbon-js-sdk/actions/runs/30436803961

After this PR is merged and exact-head staging CI passes, a lightweight immutable `v0.11.82` tag will trigger the release workflow. No npm publication or runtime deployment is part of this release.
